### PR TITLE
Make the speed instruction ready for the joint mode

### DIFF
--- a/src/demos/demo1_stand_up.cpp
+++ b/src/demos/demo1_stand_up.cpp
@@ -9,7 +9,7 @@
 #include <dynamixel/dynamixel.hpp>
 
 using namespace dynamixel;
-    
+
 void usage(char * prog);
 
 int main(int argc, char **argv) {
@@ -17,7 +17,7 @@ int main(int argc, char **argv) {
     // Getopt ///////////////////////////////////
     char controllerDevice[256] = "/dev/ttyUSB0";
     int c;
-     
+
     opterr = 0;
 
     while ((c = getopt (argc, argv, "d:")) != -1) {
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
     try
     {
         // Init ///////////////////////////////////////////////////////////////
-       
+
         // Set device file
         Usb2Dynamixel controller(controllerDevice);
 
@@ -67,12 +67,12 @@ int main(int argc, char **argv) {
             usleep(1000);                                  // Suspend execution for n microseconds
             wheels_speeds.push_back(0x0fe);                // Set wheels speed (max = 0x3fe)
         }
-        
+
         // Set wheels directions
-        wheels_directions.push_back(true);  // Wheel #4 get left 
-        wheels_directions.push_back(false); // Wheel #8 get right 
-        wheels_directions.push_back(false); // Wheel #12 get right 
-        wheels_directions.push_back(true);  // Wheel #16 get left 
+        wheels_directions.push_back(true);  // Wheel #4 get left
+        wheels_directions.push_back(false); // Wheel #8 get right
+        wheels_directions.push_back(false); // Wheel #12 get right
+        wheels_directions.push_back(true);  // Wheel #16 get left
 
         // Get status
         Status st;
@@ -101,14 +101,14 @@ int main(int argc, char **argv) {
         controller.send(set_positions);
         usleep(1000); // Suspend execution for n microseconds
 
-        ax12::SetSpeeds set_speeds(limbs_IDs, limbs_directions, limbs_speeds);
+        ax12::SetSpeeds set_speeds(limbs_IDs, limbs_speeds, limbs_directions);
         controller.send(set_speeds);
         usleep(1000); // Suspend execution for n microseconds
 
         sleep(5);     // Suspend execution for n seconds
-        controller.send(ax12::SetSpeeds(wheels_IDs, wheels_directions, wheels_speeds));
+        controller.send(ax12::SetSpeeds(wheels_IDs, wheels_speeds, wheels_directions));
 
-        while(true) 
+        while(true)
         {
             Status st;
             controller.recv(1000.5f, st);

--- a/src/demos/demo2_wriggle.cpp
+++ b/src/demos/demo2_wriggle.cpp
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
     // Getopt ///////////////////////////////////
     char controllerDevice[256] = "/dev/ttyUSB0";
     int c;
-     
+
     opterr = 0;
 
     while ((c = getopt (argc, argv, "d:")) != -1) {
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
     try
     {
         // Init ///////////////////////////////////////////////////////////////
-       
+
         // Set device file
         Usb2Dynamixel controller(controllerDevice);
 
@@ -73,12 +73,12 @@ int main(int argc, char **argv) {
             usleep(1000);                                  // Suspend execution for n microseconds
             wheels_speeds.push_back(0x0fe);                // Set wheels speed (max = 0x3fe)
         }
-        
+
         // Set wheels directions
-        wheels_directions.push_back(true);  // Wheel #4 get left 
-        wheels_directions.push_back(false); // Wheel #8 get right 
-        wheels_directions.push_back(false); // Wheel #12 get right 
-        wheels_directions.push_back(true);  // Wheel #16 get left 
+        wheels_directions.push_back(true);  // Wheel #4 get left
+        wheels_directions.push_back(false); // Wheel #8 get right
+        wheels_directions.push_back(false); // Wheel #12 get right
+        wheels_directions.push_back(true);  // Wheel #16 get left
 
         // Get status
         Status st;
@@ -100,7 +100,7 @@ int main(int argc, char **argv) {
         actuators_IDs.push_back(10);
         actuators_IDs.push_back(13);
         actuators_IDs.push_back(14);
-        
+
         Status status;
 
         // Init timers //////////////////////////
@@ -109,7 +109,7 @@ int main(int argc, char **argv) {
         struct timeval timev_cur;   // Current absolute time
         struct timeval timev_rel;   // Current relative time (curent absolute time - initial time)
         struct timeval timev_diff;  // Current tick position (curent absolute time - previous tick time)
-       
+
         timerclear(&timev_init);
         gettimeofday(&timev_init, NULL);
 
@@ -121,7 +121,7 @@ int main(int argc, char **argv) {
             actuators_positions.push_back(512);           // Set actuators positions (max = 0x3fe)
         }
 
-        ax12::SetSpeeds set_speeds(actuators_IDs, actuators_directions, actuators_speeds);
+        ax12::SetSpeeds set_speeds(actuators_IDs, actuators_speeds, actuators_directions);
         controller.send(set_speeds);
         usleep(1000); // Suspend execution for n microseconds
 

--- a/src/tools/dynamixel.cpp
+++ b/src/tools/dynamixel.cpp
@@ -423,7 +423,7 @@ void testRoues(Usb2Dynamixel& controller,unsigned  arg)
     pos[4]=200;
     pos[5]=200;
 
-    controller.send(ax12::SetSpeeds(ids, direction,pos));
+    controller.send(ax12::SetSpeeds(ids, pos, direction));
     controller.recv(READ_DURATION, status);
 
     ids[0]=7;


### PR DESCRIPTION
I'm not sure whether method overloading is the most optimal way of doing. Feel free to tell me how you would have done it.

Tested through the ROS service (only changing speeds for multiple actuators, not the one for a single).
