### PR TITLE
fix bug with open_serial

### DIFF
--- a/src/dynamixel/controllers/usb2dynamixel.hpp
+++ b/src/dynamixel/controllers/usb2dynamixel.hpp
@@ -22,7 +22,8 @@ namespace dynamixel {
 namespace controllers {
     class Usb2Dynamixel {
     public:
-        Usb2Dynamixel(const std::string& name, int baudrate = B115200, double recv_timeout = 0.1)
+        Usb2Dynamixel(const std::string& name, int baudrate = B115200, double recv_timeout = 0.1):
+            _fd(-1)
         {
             open_serial(name, baudrate, recv_timeout);
         }
@@ -32,6 +33,10 @@ namespace controllers {
         void open_serial(const std::string& name, int baudrate = B115200, double recv_timeout = 0.1)
         {
             struct termios tio_serial;
+
+            // Firstly, check that there is no active connexion
+            if (_fd != -1)
+                throw errors::Error("error attempting to open device " + name + ": an other connexion is active; call `close serial` before opening a new connexion");
 
             _fd = open(name.c_str(), O_RDWR | O_NOCTTY);
             if (_fd == -1)
@@ -104,7 +109,7 @@ namespace controllers {
 
             std::vector<uint8_t> packet;
             packet.reserve(_recv_buffer_size);
-            
+
             //std::cout << "Recv: ";
 
             do {


### PR DESCRIPTION
It used to be possible to open a new serial connexion even though the
previous one had not been closed.
