### PR TITLE
remove timeout parameter from open_serial

### DIFF
--- a/src/dynamixel/controllers/usb2dynamixel.hpp
+++ b/src/dynamixel/controllers/usb2dynamixel.hpp
@@ -23,14 +23,14 @@ namespace controllers {
     class Usb2Dynamixel {
     public:
         Usb2Dynamixel(const std::string& name, int baudrate = B115200, double recv_timeout = 0.1):
-            _fd(-1)
+            _recv_timeout(recv_timeout), _fd(-1)
         {
-            open_serial(name, baudrate, recv_timeout);
+            open_serial(name, baudrate);
         }
 
         Usb2Dynamixel() : _fd(-1) {}
 
-        void open_serial(const std::string& name, int baudrate = B115200, double recv_timeout = 0.1)
+        void open_serial(const std::string& name, int baudrate = B115200)
         {
             struct termios tio_serial;
 
@@ -58,7 +58,6 @@ namespace controllers {
             cfgetispeed(&tio_serial);
             tcflush(_fd, TCIFLUSH);
             tcsetattr(_fd, TCSANOW, &tio_serial);
-            _recv_timeout = recv_timeout;
         }
 
         void close_serial()
@@ -137,9 +136,9 @@ namespace controllers {
         }
 
     private:
-        int _fd;
         double _recv_timeout;
         static const size_t _recv_buffer_size = 256;
+        int _fd;
     };
 }
 }

--- a/src/dynamixel/controllers/usb2dynamixel.hpp
+++ b/src/dynamixel/controllers/usb2dynamixel.hpp
@@ -28,7 +28,7 @@ namespace controllers {
             open_serial(name, baudrate);
         }
 
-        Usb2Dynamixel() : _fd(-1) {}
+        Usb2Dynamixel() : _recv_timeout(0.1), _fd(-1) {}
 
         void open_serial(const std::string& name, int baudrate = B115200)
         {


### PR DESCRIPTION
The method open_serial could be called several times in the lifecycle of
the class but we might not want to change the recieve timeout, nor reset
it to the default value. Therefore, it is initialised by the constructor
(isn't it cleaner anyway ?) and still accessible with a getter and a
setter.
