### PR TITLE
adding the udev rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ The build system for this library is Waf. Don't run away yet. It has the big adv
 4. setup the proper authorisation  
   please ensure that you have the proper rights to access the serial interfaces. On GNU/Linux, you might have to add your user to the `dialout` group and log out.
 
+udev rule for USB2AX adapter
+============================
+If you want your USB2AX serial interface to appear in `/dev` as `usb2axN` (where N is a kerne-attributed integer), you can install the udev rule. It is as simple as moving the `usb2ax.rules` file in this repository to the folder for the udev rules. For ubuntu, it is `/etc/udev/rules.d`.
+
 Using the utility
 =================
 Since we are right now writing a brand new utility, the user interface is not settled yet and some commands are not implemented. You can still play with the binary `dynamixel2` (the name will change) with the `--help [command]` option to learn how to use it.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The build system for this library is Waf. Don't run away yet. It has the big adv
 
 udev rule for USB2AX adapter
 ============================
-If you want your USB2AX serial interface to appear in `/dev` as `usb2axN` (where N is a kerne-attributed integer), you can install the udev rule. It is as simple as moving the `usb2ax.rules` file in this repository to the folder for the udev rules. For ubuntu, it is `/etc/udev/rules.d`.
+If you want your USB2AX serial interface to appear in `/dev` as `usb2axN` (where N is a kernel-attributed integer), you can install the udev rule. It is as simple as moving the `usb2ax.rules` file in this repository to the folder for the udev rules. For ubuntu, it is `/etc/udev/rules.d`.
 
 Using the utility
 =================

--- a/usb2ax.rules
+++ b/usb2ax.rules
@@ -1,0 +1,1 @@
+KERNEL=="ttyACM[0-9]", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="06a7", SYMLINK="usb2ax%n", MODE="660"


### PR DESCRIPTION
I made a udev rule to distinguis the usb2ax device from our optoforce sensors. They indeed all appear as ttyACM devices.

No modification is made to the library itself.
