### PR TITLE
Make API more coherent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## Current branch
+
+- [Deprecation] removed method `get_goal_speed_angle` that only duplicated `get_moving_speed` and brought nothing
+- [Improvement] add information on the unit in error message for position and speed limit overflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Current branch
 
 - [Deprecation] removed method `get_goal_speed_angle` that only duplicated `get_moving_speed` and brought nothing
+- [API change] renamed methods `reg_goal_speed_angle` and `set_goal_speed_angle` respectively to `reg_moving_speed_angle` and `set_moving_speed_angle`
 - [Improvement] add information on the unit in error message for position and speed limit overflow

--- a/src/demos/dynamixel_test.cpp
+++ b/src/demos/dynamixel_test.cpp
@@ -29,7 +29,7 @@ int main(int argc, char** argv)
             std::cout << "Detected an " << servo->model_name() << " with ID " << servo->id() << std::endl;
             controller.send(servo->set_torque_enable(1));
             controller.recv(st);
-            controller.send(servo->set_goal_speed_angle(1));
+            controller.send(servo->set_moving_speed_angle(1));
             controller.recv(st);
             controller.send(servo->set_goal_position_angle(M_PI));
             controller.recv(st);

--- a/src/dynamixel/servos/base_servo.hpp
+++ b/src/dynamixel/servos/base_servo.hpp
@@ -153,14 +153,14 @@ namespace dynamixel {
             // =================================================================
             // Speed-specific
 
-            virtual InstructionPacket<protocol_t> set_goal_speed_angle(double rad_per_s, cst::OperatingMode operating_mode = cst::joint) const
+            virtual InstructionPacket<protocol_t> set_moving_speed_angle(double rad_per_s, cst::OperatingMode operating_mode = cst::joint) const
             {
-                throw errors::Error("set_goal_speed_angle not implemented in model");
+                throw errors::Error("set_moving_speed_angle not implemented in model");
             }
 
-            virtual InstructionPacket<protocol_t> reg_goal_speed_angle(double rad_per_s, cst::OperatingMode operating_mode = cst::joint) const
+            virtual InstructionPacket<protocol_t> reg_moving_speed_angle(double rad_per_s, cst::OperatingMode operating_mode = cst::joint) const
             {
-                throw errors::Error("reg_goal_speed_angle not implemented in model");
+                throw errors::Error("reg_moving_speed_angle not implemented in model");
             }
 
             virtual double parse_joint_speed(const StatusPacket<protocol_t>& st) const

--- a/src/dynamixel/servos/base_servo.hpp
+++ b/src/dynamixel/servos/base_servo.hpp
@@ -163,11 +163,6 @@ namespace dynamixel {
                 throw errors::Error("reg_goal_speed_angle not implemented in model");
             }
 
-            virtual InstructionPacket<protocol_t> get_goal_speed_angle() const
-            {
-                throw errors::Error("get_goal_speed_angle not implemented in model");
-            }
-
             virtual double parse_joint_speed(const StatusPacket<protocol_t>& st) const
             {
                 throw errors::Error("parse_joint_speed not implemented in model");

--- a/src/dynamixel/servos/protocol_specific_packets.hpp
+++ b/src/dynamixel/servos/protocol_specific_packets.hpp
@@ -32,12 +32,12 @@ namespace dynamixel {
                     on how the values are treated
                 @return a data packet to be sent on the serial line
             **/
-            static inline InstructionPacket<P> set_goal_speed_angle(
+            static inline InstructionPacket<P> set_moving_speed_angle(
                 typename P::id_t id,
                 double rad_per_s,
                 cst::OperatingMode operating_mode = cst::joint)
             {
-                throw errors::Error("set_goal_speed_angle not implemented for this protocol");
+                throw errors::Error("set_moving_speed_angle not implemented for this protocol");
             }
         };
 
@@ -47,7 +47,7 @@ namespace dynamixel {
             typedef typename ModelTraits<M>::CT ct_t;
             typedef typename ct_t::moving_speed_t moving_speed_t;
 
-            static inline InstructionPacket<protocols::Protocol1> set_goal_speed_angle(
+            static inline InstructionPacket<protocols::Protocol1> set_moving_speed_angle(
                 typename protocols::Protocol1::id_t id,
                 double rad_per_s,
                 cst::OperatingMode operating_mode)
@@ -58,7 +58,7 @@ namespace dynamixel {
                 return Servo<M>::set_moving_speed(id, speed_ticks);
             }
 
-            static inline InstructionPacket<protocols::Protocol1> reg_goal_speed_angle(
+            static inline InstructionPacket<protocols::Protocol1> reg_moving_speed_angle(
                 typename protocols::Protocol1::id_t id,
                 double rad_per_s,
                 cst::OperatingMode operating_mode)
@@ -115,7 +115,7 @@ namespace dynamixel {
             typedef typename ModelTraits<M>::CT ct_t;
             typedef typename ct_t::moving_speed_t moving_speed_t;
 
-            static inline InstructionPacket<protocols::Protocol2> set_goal_speed_angle(
+            static inline InstructionPacket<protocols::Protocol2> set_moving_speed_angle(
                 typename protocols::Protocol2::id_t id,
                 double rad_per_s,
                 cst::OperatingMode operating_mode)
@@ -125,7 +125,7 @@ namespace dynamixel {
                 return Servo<M>::set_moving_speed(id, speed_ticks);
             }
 
-            static inline InstructionPacket<protocols::Protocol2> reg_goal_speed_angle(
+            static inline InstructionPacket<protocols::Protocol2> reg_moving_speed_angle(
                 typename protocols::Protocol2::id_t id,
                 double rad_per_s,
                 cst::OperatingMode operating_mode)

--- a/src/dynamixel/servos/servo.hpp
+++ b/src/dynamixel/servos/servo.hpp
@@ -210,24 +210,24 @@ namespace dynamixel {
             // =================================================================
             // Speed-specific
 
-            static inline InstructionPacket<protocol_t> set_goal_speed_angle(typename Servo<Model>::protocol_t::id_t id, double rad_per_s, cst::OperatingMode operating_mode)
+            static inline InstructionPacket<protocol_t> set_moving_speed_angle(typename Servo<Model>::protocol_t::id_t id, double rad_per_s, cst::OperatingMode operating_mode)
             {
-                return ProtocolSpecificPackets<Model, protocol_t>::set_goal_speed_angle(id, rad_per_s, operating_mode);
+                return ProtocolSpecificPackets<Model, protocol_t>::set_moving_speed_angle(id, rad_per_s, operating_mode);
             }
 
-            static inline InstructionPacket<protocol_t> reg_goal_speed_angle(typename Servo<Model>::protocol_t::id_t id, double rad_per_s, cst::OperatingMode operating_mode)
+            static inline InstructionPacket<protocol_t> reg_moving_speed_angle(typename Servo<Model>::protocol_t::id_t id, double rad_per_s, cst::OperatingMode operating_mode)
             {
-                return ProtocolSpecificPackets<Model, protocol_t>::reg_goal_speed_angle(id, rad_per_s, operating_mode);
+                return ProtocolSpecificPackets<Model, protocol_t>::reg_moving_speed_angle(id, rad_per_s, operating_mode);
             }
 
-            InstructionPacket<protocol_t> set_goal_speed_angle(double rad_per_s, cst::OperatingMode operating_mode = cst::joint) const override
+            InstructionPacket<protocol_t> set_moving_speed_angle(double rad_per_s, cst::OperatingMode operating_mode = cst::joint) const override
             {
-                return Model::set_goal_speed_angle(this->_id, rad_per_s, operating_mode);
+                return Model::set_moving_speed_angle(this->_id, rad_per_s, operating_mode);
             }
 
-            InstructionPacket<protocol_t> reg_goal_speed_angle(double rad_per_s, cst::OperatingMode operating_mode = cst::joint) const override
+            InstructionPacket<protocol_t> reg_moving_speed_angle(double rad_per_s, cst::OperatingMode operating_mode = cst::joint) const override
             {
-                return Model::reg_goal_speed_angle(this->_id, rad_per_s, operating_mode);
+                return Model::reg_moving_speed_angle(this->_id, rad_per_s, operating_mode);
             }
 
             // TODO: read speed from dynamixel pros to check that we do get negative values too

--- a/src/dynamixel/servos/servo.hpp
+++ b/src/dynamixel/servos/servo.hpp
@@ -230,17 +230,6 @@ namespace dynamixel {
                 return Model::reg_goal_speed_angle(this->_id, rad_per_s, operating_mode);
             }
 
-            // These two methods are not necessary, should We delete them ?
-            static InstructionPacket<typename Servo<Model>::protocol_t> get_goal_speed_angle(typename Servo<Model>::protocol_t::id_t id)
-            {
-                return get_moving_speed(id);
-            }
-
-            InstructionPacket<typename Servo<Model>::protocol_t> get_goal_speed_angle() const override
-            {
-                return Model::get_goal_speed_angle(this->_id);
-            }
-
             // TODO: read speed from dynamixel pros to check that we do get negative values too
             // FIXME : replace the following by protocol specific methods ?
             static double parse_joint_speed(typename Servo<Model>::protocol_t::id_t id, const StatusPacket<typename Servo<Model>::protocol_t>& st)

--- a/src/dynamixel/servos/servo.hpp
+++ b/src/dynamixel/servos/servo.hpp
@@ -230,6 +230,7 @@ namespace dynamixel {
                 return Model::reg_goal_speed_angle(this->_id, rad_per_s, operating_mode);
             }
 
+            // These two methods are not necessary, should We delete them ?
             static InstructionPacket<typename Servo<Model>::protocol_t> get_goal_speed_angle(typename Servo<Model>::protocol_t::id_t id)
             {
                 return get_moving_speed(id);

--- a/src/tools/utility.hpp
+++ b/src/tools/utility.hpp
@@ -561,7 +561,7 @@ namespace dynamixel {
             for (auto id : ids) {
                 StatusPacket<Protocol> status;
                 // request current position
-                _serial_interface.send(_servos.at(id)->get_goal_speed_angle());
+                _serial_interface.send(_servos.at(id)->get_moving_speed());
                 _serial_interface.recv(status);
 
                 // parse response to get the position
@@ -600,7 +600,7 @@ namespace dynamixel {
                 StatusPacket<Protocol> status;
                 // request current position
                 _serial_interface.send(
-                    servo.second->get_goal_speed_angle());
+                    servo.second->get_moving_speed());
                 _serial_interface.recv(status);
 
                 // parse response to get the position

--- a/src/tools/utility.hpp
+++ b/src/tools/utility.hpp
@@ -459,7 +459,7 @@ namespace dynamixel {
             // the new speed is sent to each actuator but they wait for the
             // "Action" (see bellow) command to enact the change
             for (auto id : ids) {
-                _serial_interface.send(_servos.at(id)->reg_goal_speed_angle(
+                _serial_interface.send(_servos.at(id)->reg_moving_speed_angle(
                     speed,
                     wheel_mode ? cst::wheel : cst::joint));
 
@@ -492,7 +492,7 @@ namespace dynamixel {
             // the new speed is sent to each actuator but they wait for the
             // "Action" (see bellow) command to enact the change
             for (auto servo : _servos) {
-                _serial_interface.send(servo.second->reg_goal_speed_angle(speed,
+                _serial_interface.send(servo.second->reg_moving_speed_angle(speed,
                     wheel_mode ? cst::wheel : cst::joint));
 
                 StatusPacket<Protocol> status;
@@ -532,7 +532,7 @@ namespace dynamixel {
 
             for (int i = 0; i < ids.size(); i++) {
                 _serial_interface.send(
-                    _servos.at(ids[i])->reg_goal_speed_angle(speeds[i],
+                    _servos.at(ids[i])->reg_moving_speed_angle(speeds[i],
                         wheel_mode ? cst::wheel : cst::joint));
 
                 StatusPacket<Protocol> status;


### PR DESCRIPTION
These modifications rename the speed-related methods to be more coherent and removes a useless method.

@costashatz @jbmouret please check if you have any code using speed-related commands.