### PR TITLE
Header detection

### DIFF
--- a/src/dynamixel/controllers/file2dynamixel.hpp
+++ b/src/dynamixel/controllers/file2dynamixel.hpp
@@ -1,0 +1,208 @@
+#ifndef DYNAMIXEL_CONTROLLERS_FILE2DYNAMIXEL_HPP_
+#define DYNAMIXEL_CONTROLLERS_FILE2DYNAMIXEL_HPP_
+
+#include <fcntl.h>
+#include <errno.h>
+#include <termios.h>
+#include <vector>
+#include <cstdio>
+#include <stdint.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <iostream>
+#include <cstring>
+#include <sstream>
+#include <iomanip>
+
+#include "../errors/error.hpp"
+#include "../misc.hpp"
+#include "../instruction_packet.hpp"
+#include "../status_packet.hpp"
+
+namespace dynamixel {
+    namespace controllers {
+        /** Class to emulate communication with servos.
+
+            By using a file, we can emulate sending packets and receiving them.
+            This class is used for testing and debugging only.
+        **/
+        class File2Dynamixel {
+            // TODO : declare private copy constructor and assignment operator
+        public:
+            File2Dynamixel(const std::string& name)
+                : _fd(-1), _report_bad_packet(false)
+            {
+                open_file(name);
+            }
+
+            File2Dynamixel(const std::string& name, int flags)
+                : _fd(-1), _report_bad_packet(false)
+            {
+                open_file(name, flags);
+            }
+
+            File2Dynamixel(const std::string& name, int flags, mode_t mode)
+                : _fd(-1), _report_bad_packet(false)
+            {
+                open_file(name, flags, mode);
+            }
+
+            File2Dynamixel() : _fd(-1), _report_bad_packet(false) {}
+
+            ~File2Dynamixel()
+            {
+                close_file();
+            }
+
+            void open_file(const std::string& name,
+                int flags = (O_RDWR | O_CREAT | O_APPEND),
+                mode_t mode = (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH))
+            {
+                if (_fd != -1)
+                    throw errors::Error("error attempting to open file " + name + ": an other file is open; call `close_file` before opening a new file");
+
+                // open the file
+                _fd = open(name.c_str(), flags, mode);
+                if (_fd == -1)
+                    throw errors::Error("error opening file " + name + ": " + std::string(strerror(errno)));
+            }
+
+            void close_file()
+            {
+                close(_fd);
+                _fd = -1;
+            }
+
+            bool is_open() { return !(_fd == -1); }
+
+            off_t seek(unsigned int offset)
+            {
+                return lseek(_fd, (off_t)offset, SEEK_SET);
+            }
+
+            // send for instruction packets
+            template <typename T>
+            void send(const InstructionPacket<T>& packet) const
+            {
+                if (_fd == -1)
+                    return;
+
+                int ret = write(_fd, packet.data(), packet.size());
+
+                std::cout << "Send: ";
+                for (size_t i = 0; i < packet.size(); ++i)
+                    std::cout << "0x" << std::setfill('0') << std::setw(2) << std::hex << (unsigned int)packet[i] << " ";
+                std::cout << std::endl;
+
+                if (ret != packet.size()) {
+                    std::stringstream ofs;
+                    perror("write:");
+                    ofs << "written= " << ret << ", size=" << packet.size();
+                    throw errors::Error("File2Dynamixel::Send: packet not fully written" + ofs.str());
+                }
+            }
+
+            // generic send
+            void send(const std::vector<uint8_t>& packet) const
+            {
+                if (_fd == -1)
+                    return;
+
+                int ret = write(_fd, &packet.front(), packet.size());
+
+                std::cout << "Send: ";
+                for (size_t i = 0; i < packet.size(); ++i)
+                    std::cout << "0x" << std::setfill('0') << std::setw(2) << std::hex << (unsigned int)packet[i] << " ";
+                std::cout << std::endl;
+
+                if (ret != packet.size()) {
+                    std::stringstream ofs;
+                    perror("write:");
+                    ofs << "written= " << ret << ", size=" << packet.size();
+                    throw errors::Error("File2Dynamixel::Send: packet not fully written" + ofs.str());
+                }
+            }
+
+            // general receive
+            template <typename T>
+            bool recv(StatusPacket<T>& status) const
+            {
+                using DecodeState = typename T::DecodeState;
+
+                if (_fd == -1)
+                    return false;
+
+                int res = 0;
+                DecodeState state = DecodeState::ONGOING;
+
+                std::vector<uint8_t> packet;
+                packet.reserve(_recv_buffer_size);
+
+                std::cout << "Recieve:" << std::endl;
+
+                do {
+                    uint8_t byte;
+                    res = read(_fd, &byte, 1);
+
+                    if (res > 0) {
+                        // std::cout << std::setfill('0') << std::setw(2)
+                        //           << std::hex << (unsigned int)byte << " ";
+                        packet.push_back(byte);
+
+                        state = status.decode_packet(packet, _report_bad_packet);
+                        if (state == DecodeState::INVALID) {
+                            std::cout << "\tBad packet: ";
+                            for (const auto byte : packet)
+                                std::cout << std::setfill('0') << std::setw(2) << std::hex << (unsigned int)byte << " ";
+                            std::cout << std::endl;
+
+                            packet.clear();
+                        }
+                        else if (state == DecodeState::DONE) {
+                            std::cout << "\tGood packet: ";
+                            for (const auto byte : packet)
+                                std::cout << std::setfill('0') << std::setw(2) << std::hex << (unsigned int)byte << " ";
+                            std::cout << std::endl;
+                        }
+                    }
+                } while (state != DecodeState::DONE && res);
+
+                std::cout << "Status in the end is ";
+                switch (state) {
+                case DecodeState::INVALID:
+                    std::cout << "INVALID";
+                    break;
+                case DecodeState::ONGOING:
+                    std::cout << "ONGOING";
+                    break;
+                case DecodeState::DONE:
+                    std::cout << "DONE";
+                    break;
+                }
+                std::cout << std::endl;
+
+                //std::cout << std::endl;
+                std::cout << std::dec;
+
+                return true;
+            }
+
+            void set_report_bad_packet(bool report_bad_packet)
+            {
+                _report_bad_packet = report_bad_packet;
+            }
+
+            bool report_bad_packet()
+            {
+                return _report_bad_packet;
+            }
+
+        private:
+            static const size_t _recv_buffer_size = 256;
+            int _fd;
+            bool _report_bad_packet;
+        };
+    }
+}
+
+#endif

--- a/src/dynamixel/controllers/file2dynamixel.hpp
+++ b/src/dynamixel/controllers/file2dynamixel.hpp
@@ -167,18 +167,18 @@ namespace dynamixel {
                     }
                 } while (state != DecodeState::DONE && res);
 
-                std::cout << "Status in the end is ";
-                switch (state) {
-                case DecodeState::INVALID:
-                    std::cout << "INVALID";
-                    break;
-                case DecodeState::ONGOING:
-                    std::cout << "ONGOING";
-                    break;
-                case DecodeState::DONE:
-                    std::cout << "DONE";
-                    break;
-                }
+                // std::cout << "Status in the end is ";
+                // switch (state) {
+                // case DecodeState::INVALID:
+                //     std::cout << "INVALID";
+                //     break;
+                // case DecodeState::ONGOING:
+                //     std::cout << "ONGOING";
+                //     break;
+                // case DecodeState::DONE:
+                //     std::cout << "DONE";
+                //     break;
+                // }
                 std::cout << std::endl;
 
                 //std::cout << std::endl;

--- a/src/dynamixel/controllers/file2dynamixel.hpp
+++ b/src/dynamixel/controllers/file2dynamixel.hpp
@@ -138,7 +138,7 @@ namespace dynamixel {
                 std::vector<uint8_t> packet;
                 packet.reserve(_recv_buffer_size);
 
-                std::cout << "Recieve:" << std::endl;
+                std::cout << "Receive:" << std::endl;
 
                 do {
                     uint8_t byte;

--- a/src/dynamixel/controllers/usb2dynamixel.hpp
+++ b/src/dynamixel/controllers/usb2dynamixel.hpp
@@ -118,7 +118,7 @@ namespace dynamixel {
                 std::vector<uint8_t> packet;
                 packet.reserve(_recv_buffer_size);
 
-                //std::cout << "Recieve:" << std::endl;
+                //std::cout << "Receive:" << std::endl;
 
                 do {
                     double current_time = get_time();

--- a/src/dynamixel/controllers/usb2dynamixel.hpp
+++ b/src/dynamixel/controllers/usb2dynamixel.hpp
@@ -118,15 +118,31 @@ namespace dynamixel {
 
                 do {
                     double current_time = get_time();
-                    uint8_t b;
-                    int res = read(_fd, &b, 1);
+                    uint8_t byte;
+                    int res = read(_fd, &byte, 1);
                     if (res > 0) {
-                        packet.push_back(b);
+                        packet.push_back(byte);
+
+                        if (!T::detect_status_header(packet)) {
+                            std::cout << "Bad packet: ";
+                            for (const auto byte : packet)
+                                std::cout << std::setfill('0') << std::setw(2) << std::hex << (unsigned int)byte << " ";
+                            std::cout << std::endl;
+                            packet.clear();
+                        }
+                        else {
+                            //  std::cout << "0x" << std::setfill('0') << std::setw(2) << std::hex << (unsigned int)byte << " ";
+
+                            done = status.decode_packet(packet);
+                            // if (done) {
+                            //     std::cout << "Good packet: ";
+                            //     for (const auto byte : packet)
+                            //         std::cout << std::setfill('0') << std::setw(2) << std::hex << (unsigned int)byte << " ";
+                            //     std::cout << std::endl;
+                            // }
+                        }
+
                         time = current_time;
-
-                        //  std::cout << "0x" << std::setfill('0') << std::setw(2) << std::hex << (unsigned int)b << " ";
-
-                        done = status.decode_packet(packet);
                     }
 
                     if (current_time - time > _recv_timeout) {
@@ -136,6 +152,7 @@ namespace dynamixel {
                 } while (!done);
 
                 //std::cout << std::endl;
+                std::cout << std::dec;
 
                 return true;
             }

--- a/src/dynamixel/controllers/usb2dynamixel.hpp
+++ b/src/dynamixel/controllers/usb2dynamixel.hpp
@@ -23,12 +23,14 @@ namespace dynamixel {
         class Usb2Dynamixel {
             // TODO : declare private copy constructor and assignment operator
         public:
-            Usb2Dynamixel(const std::string& name, int baudrate = B115200, double recv_timeout = 0.1) : _recv_timeout(recv_timeout), _fd(-1)
+            Usb2Dynamixel(const std::string& name, int baudrate = B115200, double recv_timeout = 0.1)
+                : _recv_timeout(recv_timeout), _fd(-1), _report_bad_packet(false)
             {
                 open_serial(name, baudrate);
             }
 
-            Usb2Dynamixel() : _recv_timeout(0.1), _fd(-1) {}
+            Usb2Dynamixel()
+                : _recv_timeout(0.1), _fd(-1), _report_bad_packet(false) {}
 
             ~Usb2Dynamixel()
             {
@@ -105,51 +107,44 @@ namespace dynamixel {
             template <typename T>
             bool recv(StatusPacket<T>& status) const
             {
+                using DecodeState = typename T::DecodeState;
+
                 if (_fd == -1)
                     return false;
 
                 double time = get_time();
-                bool done = false;
+                DecodeState state = DecodeState::ONGOING;
 
                 std::vector<uint8_t> packet;
                 packet.reserve(_recv_buffer_size);
 
-                //std::cout << "Recv: ";
+                //std::cout << "Recieve:" << std::endl;
 
                 do {
                     double current_time = get_time();
                     uint8_t byte;
                     int res = read(_fd, &byte, 1);
                     if (res > 0) {
+                        // std::cout << std::setfill('0') << std::setw(2)
+                        //           << std::hex << (unsigned int)byte << " ";
                         packet.push_back(byte);
 
-                        if (!T::detect_status_header(packet)) {
-                            std::cout << "Bad packet: ";
-                            for (const auto byte : packet)
-                                std::cout << std::setfill('0') << std::setw(2) << std::hex << (unsigned int)byte << " ";
-                            std::cout << std::endl;
-                            packet.clear();
-                        }
-                        else {
-                            //  std::cout << "0x" << std::setfill('0') << std::setw(2) << std::hex << (unsigned int)byte << " ";
+                        state = status.decode_packet(packet, _report_bad_packet);
+                        if (state == DecodeState::INVALID) {
+                            // std::cout << "\tBad packet: ";
+                            // for (const auto byte : packet)
+                            //     std::cout << std::setfill('0') << std::setw(2) << std::hex << (unsigned int)byte << " ";
+                            // std::cout << std::endl;
 
-                            done = status.decode_packet(packet);
-                            // if (done) {
-                            //     std::cout << "Good packet: ";
-                            //     for (const auto byte : packet)
-                            //         std::cout << std::setfill('0') << std::setw(2) << std::hex << (unsigned int)byte << " ";
-                            //     std::cout << std::endl;
-                            // }
+                            packet.clear();
                         }
 
                         time = current_time;
                     }
 
-                    if (current_time - time > _recv_timeout) {
-                        //std::cout << std::endl;
+                    if (current_time - time > _recv_timeout)
                         return false;
-                    }
-                } while (!done);
+                } while (state != DecodeState::DONE);
 
                 //std::cout << std::endl;
                 std::cout << std::dec;
@@ -157,10 +152,29 @@ namespace dynamixel {
                 return true;
             }
 
+            /** Enable error reporting for packet issues
+
+                If report_bad_packet is set to true, invalid packet headers and
+                errors in packet size are reported through exceptions.
+            **/
+            void set_report_bad_packet(bool report_bad_packet)
+            {
+                _report_bad_packet = report_bad_packet;
+            }
+
+            /**
+                @see set_report_bad_packet
+            **/
+            bool report_bad_packet()
+            {
+                return _report_bad_packet;
+            }
+
         private:
             double _recv_timeout;
             static const size_t _recv_buffer_size = 256;
             int _fd;
+            bool _report_bad_packet;
         };
     }
 }

--- a/src/dynamixel/errors.hpp
+++ b/src/dynamixel/errors.hpp
@@ -2,6 +2,7 @@
 #define DYNAMIXEL_ERRORS_HPP_
 
 #include "errors/error.hpp"
+#include "errors/bad_packet.hpp"
 #include "errors/crc_error.hpp"
 #include "errors/servo_limit_error.hpp"
 #include "errors/status_error.hpp"

--- a/src/dynamixel/errors.hpp
+++ b/src/dynamixel/errors.hpp
@@ -3,6 +3,8 @@
 
 #include "errors/error.hpp"
 #include "errors/crc_error.hpp"
+#include "errors/servo_limit_error.hpp"
 #include "errors/status_error.hpp"
+#include "errors/unpack_error.hpp"
 
 #endif

--- a/src/dynamixel/errors/bad_packet.hpp
+++ b/src/dynamixel/errors/bad_packet.hpp
@@ -1,0 +1,45 @@
+#ifndef DYNAMIXEL_BAD_PACKET_ERROR_HPP_
+#define DYNAMIXEL_BAD_PACKET_ERROR_HPP_
+
+#include <string>
+#include <stdint.h>
+
+#include "error.hpp"
+
+namespace dynamixel {
+    namespace errors {
+
+        class BadPacket : public Error {
+        public:
+            BadPacket(const std::vector<uint8_t> packet, const char* msg) : _packet(packet)
+            {
+                this->_msg = msg;
+            }
+
+            const std::vector<uint8_t> packet() const
+            {
+                return _packet;
+            }
+
+            virtual std::ostream& print(std::ostream& os) const override
+            {
+                // output the error message
+                os << _msg;
+
+                // add the packet itself
+                os << " ( " << std::hex;
+                for (uint8_t byte : _packet) {
+                    os << std::setfill('0') << std::setw(2) << (int)byte << " ";
+                }
+                os << ")" << std::dec;
+
+                return os;
+            }
+
+        private:
+            const std::vector<uint8_t> _packet;
+        };
+    }
+}
+
+#endif

--- a/src/dynamixel/errors/crc_error.hpp
+++ b/src/dynamixel/errors/crc_error.hpp
@@ -14,8 +14,9 @@ namespace dynamixel {
             CrcError(uint8_t id, uint8_t protocol, uint32_t expected, uint32_t received) : _id(id), _protocol(protocol), _expected(expected), _received(received)
             {
                 std::stringstream err_message;
-                err_message << "Status: checksum error while decoding packet with ID " << (int)id << ": ";
-                err_message << ": expected " << expected << ", received " << received;
+                err_message << "Status: checksum error while decoding packet with ID " << (int)id;
+                err_message << std::hex << ": expected " << expected << ", received " << received;
+                err_message << std::dec;
                 this->_msg = err_message.str();
             }
 

--- a/src/dynamixel/errors/error.hpp
+++ b/src/dynamixel/errors/error.hpp
@@ -25,6 +25,13 @@ namespace dynamixel {
                 return _msg;
             }
 
+            virtual std::ostream& print(std::ostream& os) const
+            {
+                os << _msg;
+
+                return os;
+            }
+
         protected:
             std::string _msg;
         };
@@ -34,6 +41,11 @@ namespace dynamixel {
         {
             if (!value)
                 throw Error(msg + std::string("[") + std::string(file) + "]");
+        }
+
+        inline std::ostream& operator<<(std::ostream& os, const Error& err)
+        {
+            return err.print(os);
         }
     }
 }

--- a/src/dynamixel/protocols/protocol1.hpp
+++ b/src/dynamixel/protocols/protocol1.hpp
@@ -183,8 +183,11 @@ namespace dynamixel {
 
                 // Compute checksum and compare with the one we received
                 uint8_t checksum = _checksum(packet);
-                if (checksum != packet.back())
-                    throw errors::CrcError(id, 1, checksum, packet.back());
+                if (checksum != packet.back()) {
+                    if (throw_exceptions)
+                        throw errors::CrcError(id, 1, checksum, packet.back());
+                    return INVALID;
+                }
 
                 uint8_t error = packet[4];
 

--- a/src/dynamixel/protocols/protocol1.hpp
+++ b/src/dynamixel/protocols/protocol1.hpp
@@ -136,12 +136,12 @@ namespace dynamixel {
                                     "implemented in Protocol1");
             }
 
-            /** Decodes the content of a status packet recieved from the servos
+            /** Decodes the content of a status packet received from the servos
 
             This method is only used by the StatusPacket class, to make it
             independent of the protocol version.
 
-            @param packet content of the recieved packet
+            @param packet content of the received packet
             @param id id of the sending actuator
             @param parameters parameters of the status packet, filled by unpack_status
             @param throw_exceptions boolean telling to throw exceptions if the
@@ -181,7 +181,7 @@ namespace dynamixel {
                 if (length > packet.size() - 4)
                     return ONGOING;
 
-                // Compute checksum and compare with the one we recieved
+                // Compute checksum and compare with the one we received
                 uint8_t checksum = _checksum(packet);
                 if (checksum != packet.back())
                     throw errors::CrcError(id, 1, checksum, packet.back());
@@ -221,7 +221,7 @@ namespace dynamixel {
         protected:
             /** Check if the packet contains a header.
 
-                @param packet data of the recieved packet
+                @param packet data of the received packet
 
                 @return true if and only if a full header was found at the
                     beginning of the packet

--- a/src/dynamixel/protocols/protocol1.hpp
+++ b/src/dynamixel/protocols/protocol1.hpp
@@ -129,6 +129,13 @@ namespace dynamixel {
                                     "implemented in Protocol1");
             }
 
+            /** Check if the packet contains a header.
+
+                @param packet data of the recieved packet
+
+                @return true if and only if a full header was found at the
+                    beginning of the packet
+            **/
             static bool detect_status_header(const std::vector<uint8_t>& packet)
             {
                 if (packet.size() >= 1 && packet[0] != 0xFF)
@@ -157,7 +164,7 @@ namespace dynamixel {
                 if (packet.size() < 6)
                     return false;
 
-                if (packet[0] != 0xFF || packet[1] != 0xFF)
+                if (!detect_status_header(packet))
                     throw errors::Error("Status: bad packet header");
 
                 id = packet[2];

--- a/src/dynamixel/protocols/protocol1.hpp
+++ b/src/dynamixel/protocols/protocol1.hpp
@@ -129,6 +129,15 @@ namespace dynamixel {
                                     "implemented in Protocol1");
             }
 
+            static bool detect_status_header(const std::vector<uint8_t>& packet)
+            {
+                if (packet.size() >= 1 && packet[0] != 0xFF)
+                    return false;
+                if (packet.size() >= 2 && packet[1] != 0xFF)
+                    return false;
+                return true;
+            }
+
             /** Decodes the content of a status packet recieved from the servos
 
             This method is only used by the StatusPacket class, to make it generic

--- a/src/dynamixel/protocols/protocol2.hpp
+++ b/src/dynamixel/protocols/protocol2.hpp
@@ -154,6 +154,17 @@ namespace dynamixel {
                 res = (((int32_t)packet[3]) << 24) | (((int32_t)packet[2]) << 16) | (((int32_t)packet[1]) << 8) | ((int32_t)packet[0]);
             }
 
+            static bool detect_status_header(const std::vector<uint8_t>& packet)
+            {
+                if (packet.size() >= 1 && packet[0] != 0xFF)
+                    return false;
+                if (packet.size() >= 2 && packet[1] != 0xFF)
+                    return false;
+                if (packet.size() >= 3 && packet[2] != 0xFD)
+                    return false;
+                return true;
+            }
+
             /** Decodes the content of a status packet recieved from the servos
 
             @see unpack_status in protocol1.hpp

--- a/src/dynamixel/protocols/protocol2.hpp
+++ b/src/dynamixel/protocols/protocol2.hpp
@@ -160,7 +160,7 @@ namespace dynamixel {
                 res = (((int32_t)packet[3]) << 24) | (((int32_t)packet[2]) << 16) | (((int32_t)packet[1]) << 8) | ((int32_t)packet[0]);
             }
 
-            /** Decodes the content of a status packet recieved from the servos
+            /** Decodes the content of a status packet received from the servos
 
                 @see unpack_status in protocol1.hpp
             **/
@@ -200,7 +200,7 @@ namespace dynamixel {
                 if (packet[7] != 0x55)
                     return INVALID;
 
-                // Compute checksum and compare with the one we recieved
+                // Compute checksum and compare with the one we received
                 uint16_t checksum = _checksum(packet);
                 uint16_t recv_checksum = (((uint16_t)packet.back()) << 8) | packet[packet.size() - 2];
                 if (checksum != recv_checksum)
@@ -254,7 +254,7 @@ namespace dynamixel {
 
                 @see detect_status_header in protocol1.hpp
 
-                @param packet data of the recieved packet
+                @param packet data of the received packet
 
                 @return true if and only if a full header was found at the
                     beginning of the packet

--- a/src/dynamixel/protocols/protocol2.hpp
+++ b/src/dynamixel/protocols/protocol2.hpp
@@ -203,8 +203,11 @@ namespace dynamixel {
                 // Compute checksum and compare with the one we received
                 uint16_t checksum = _checksum(packet);
                 uint16_t recv_checksum = (((uint16_t)packet.back()) << 8) | packet[packet.size() - 2];
-                if (checksum != recv_checksum)
-                    throw errors::CrcError(id, 2, checksum, recv_checksum);
+                if (checksum != recv_checksum) {
+                    if (throw_exceptions)
+                        throw errors::CrcError(id, 2, checksum, recv_checksum);
+                    return INVALID;
+                }
 
                 uint8_t error = packet[8];
 

--- a/src/dynamixel/protocols/protocol2.hpp
+++ b/src/dynamixel/protocols/protocol2.hpp
@@ -154,6 +154,15 @@ namespace dynamixel {
                 res = (((int32_t)packet[3]) << 24) | (((int32_t)packet[2]) << 16) | (((int32_t)packet[1]) << 8) | ((int32_t)packet[0]);
             }
 
+            /** Check if the packet contains a header.
+
+                @see detect_status_header in protocol1.hpp
+
+                @param packet data of the recieved packet
+
+                @return true if and only if a full header was found at the
+                    beginning of the packet
+            **/
             static bool detect_status_header(const std::vector<uint8_t>& packet)
             {
                 if (packet.size() >= 1 && packet[0] != 0xFF)
@@ -175,7 +184,7 @@ namespace dynamixel {
                 if (packet.size() < 11)
                     return false;
 
-                if (packet[0] != 0xFF || packet[1] != 0xFF || packet[2] != 0xFD)
+                if (!detect_status_header(packet))
                     throw errors::Error("Status: bad packet header");
 
                 // the field at position 3 in the packet is a predefined value

--- a/src/dynamixel/status_packet.hpp
+++ b/src/dynamixel/status_packet.hpp
@@ -11,6 +11,8 @@ namespace dynamixel {
     template <class Protocol>
     class StatusPacket {
     public:
+        using DecodeState = typename Protocol::DecodeState;
+
         StatusPacket() : _valid(false) {}
 
         bool valid() const { return _valid; }
@@ -29,10 +31,14 @@ namespace dynamixel {
             return _parameters;
         }
 
-        bool decode_packet(const std::vector<uint8_t>& packet)
+        DecodeState decode_packet(const std::vector<uint8_t>& packet, bool report_bad_packet = false)
         {
-            _valid = Protocol::unpack_status(packet, _id, _parameters);
-            return _valid;
+            DecodeState state = Protocol::unpack_status(packet, _id, _parameters, report_bad_packet);
+
+            if (state == DecodeState::DONE)
+                _valid = true;
+
+            return state;
         }
 
         std::ostream& print(std::ostream& os) const

--- a/src/tests/generate_packets.cpp
+++ b/src/tests/generate_packets.cpp
@@ -39,6 +39,10 @@ void test_unpack_status_1()
         packet = {0xFD, 0x00, 0x25, 0xFF, 0xDD, 0x00, 0xFF, 0xFF, 0x00, 0x02, 0x00, 0xFD};
         interface.send(packet);
 
+        // a valid packet, except for the checksum
+        packet = {0xFF, 0xFF, 0x00, 0x02, 0x00, 0xF0};
+        interface.send(packet);
+
         // An error is reported by actuator 4 (over-heating and over-load)
         packet = {0xFF, 0xFF, 0x04, 0x02, 0x24, 0xD5};
         interface.send(packet);
@@ -53,7 +57,11 @@ void test_unpack_status_1()
         flags = O_RDONLY;
         interface.open_file("frames.dat", flags);
         interface.recv(status);
+        std::cout << status << std::endl;
         interface.recv(status);
+        std::cout << status << std::endl;
+        interface.recv(status);
+        std::cout << status << std::endl;
         interface.recv(status);
     }
     catch (dynamixel::errors::BadPacket e) {
@@ -86,6 +94,10 @@ void test_unpack_status_2()
         packet = {0xFD, 0x00, 0x25, 0xFF, 0xFF, 0xFD, 0x00, 0x01, 0x07, 0x00, 0x55, 0x00, 0x06, 0x04, 0x26, 0x65, 0x5D};
         interface.send(packet);
 
+        // a valid packet, except for the checksum
+        packet = {0xFF, 0xFF, 0xFD, 0x00, 0x01, 0x07, 0x00, 0x55, 0x00, 0x06, 0x04, 0x26, 0x65, 0x00};
+        interface.send(packet);
+
         // An error is reported by actuator 4 (harware error and result fail)
         packet = {0xFF, 0xFF, 0xFD, 0x00, 0x04, 0x08, 0x00, 0x55, 0x84, 0xA6, 0x00, 0x00, 0x00, 0x8C, 0xE2};
         interface.send(packet);
@@ -99,6 +111,8 @@ void test_unpack_status_2()
             status;
         flags = O_RDONLY;
         interface.open_file("frames.dat", flags);
+        interface.recv(status);
+        std::cout << status << std::endl;
         interface.recv(status);
         std::cout << status << std::endl;
         interface.recv(status);

--- a/src/tests/generate_packets.cpp
+++ b/src/tests/generate_packets.cpp
@@ -1,0 +1,115 @@
+#include <vector>
+#include <sys/types.h>
+
+#include "../dynamixel/controllers/file2dynamixel.hpp"
+
+using namespace dynamixel;
+using namespace protocols;
+using namespace controllers;
+
+void test_unpack_status_1();
+void test_unpack_status_2();
+
+int main()
+{
+    // test_unpack_status_1();
+    test_unpack_status_2();
+    return 0;
+}
+
+void test_unpack_status_1()
+{
+    try {
+        std::cout << "writing packet to file frames.dat" << std::endl;
+
+        // open the file with options respectively read/write, create if
+        // file does not exit, truncate if file exists already
+        // the file's mode is rw-rw-rw-
+        int flags = (O_WRONLY | O_CREAT | O_TRUNC);
+        File2Dynamixel interface("frames.dat", flags);
+
+        // Good packet followed by the half of a packet header
+        std::vector<uint8_t> packet = {0xFF, 0xFF, 0x01, 0x03, 0x00, 0x20, 0xDB, 0xFF};
+        interface.send(packet);
+
+        packet = {0xFF, 0xFF, 0x00, 0x02, 0x00, 0xFD};
+        interface.send(packet);
+
+        // A valid packet prepended with rubbish data
+        packet = {0xFD, 0x00, 0x25, 0xFF, 0xDD, 0x00, 0xFF, 0xFF, 0x00, 0x02, 0x00, 0xFD};
+        interface.send(packet);
+
+        // An error is reported by actuator 4 (over-heating and over-load)
+        packet = {0xFF, 0xFF, 0x04, 0x02, 0x24, 0xD5};
+        interface.send(packet);
+
+        interface.close_file();
+
+        interface.set_report_bad_packet(false);
+
+        // Reading from the file
+        StatusPacket<Protocol1>
+            status;
+        flags = O_RDONLY;
+        interface.open_file("frames.dat", flags);
+        interface.recv(status);
+        interface.recv(status);
+        interface.recv(status);
+    }
+    catch (dynamixel::errors::BadPacket e) {
+        std::cout << "Catched exception\n\t" << e << std::endl;
+    }
+    catch (dynamixel::errors::Error e) {
+        std::cout << "Catched exception\n\t" << e.msg() << std::endl;
+    }
+}
+
+void test_unpack_status_2()
+{
+    try {
+        std::cout << "writing packet to file frames.dat" << std::endl;
+
+        // open the file with options respectively read/write, create if
+        // file does not exit, truncate if file exists already
+        // the file's mode is rw-rw-rw-
+        int flags = (O_WRONLY | O_CREAT | O_TRUNC);
+        File2Dynamixel interface("frames.dat", flags);
+
+        // Good packet followed by the half of a packet header
+        std::vector<uint8_t> packet = {0xFF, 0xFF, 0xFD, 0x00, 0x01, 0x07, 0x00, 0x55, 0x00, 0x06, 0x04, 0x26, 0x65, 0x5D, 0xFF};
+        interface.send(packet);
+
+        packet = {0xFF, 0xFF, 0xFD, 0x00, 0x01, 0x07, 0x00, 0x55, 0x00, 0x06, 0x04, 0x26, 0x65, 0x5D};
+        interface.send(packet);
+
+        // A valid packet prepended with rubbish data
+        packet = {0xFD, 0x00, 0x25, 0xFF, 0xFF, 0xFD, 0x00, 0x01, 0x07, 0x00, 0x55, 0x00, 0x06, 0x04, 0x26, 0x65, 0x5D};
+        interface.send(packet);
+
+        // An error is reported by actuator 4 (harware error and result fail)
+        packet = {0xFF, 0xFF, 0xFD, 0x00, 0x04, 0x08, 0x00, 0x55, 0x84, 0xA6, 0x00, 0x00, 0x00, 0x8C, 0xE2};
+        interface.send(packet);
+
+        interface.close_file();
+
+        interface.set_report_bad_packet(false);
+
+        // Reading from the file
+        StatusPacket<Protocol2>
+            status;
+        flags = O_RDONLY;
+        interface.open_file("frames.dat", flags);
+        interface.recv(status);
+        std::cout << status << std::endl;
+        interface.recv(status);
+        std::cout << status << std::endl;
+        interface.recv(status);
+        std::cout << status << std::endl;
+    }
+    catch (dynamixel::errors::BadPacket e) {
+        std::cout << "Catched exception\n\t" << e << std::endl;
+    }
+    catch (dynamixel::errors::Error e) {
+        std::cout << "Catched exception\n\t" << e << std::endl;
+    }
+}

--- a/src/tests/wscript
+++ b/src/tests/wscript
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def configure(bld):
+    pass
+
+def options(bld):
+    pass
+
+def build(bld):
+    bld(features='cxx cxxprogram', source='generate_packets.cpp', target="generate_packets", includes=". ..")

--- a/src/tools/utility.hpp
+++ b/src/tools/utility.hpp
@@ -62,7 +62,7 @@ namespace dynamixel {
         }
 
         /** Return the connected actuators.
-            If we didn't do a scanning yet, does it with the default recieve
+            If we didn't do a scanning yet, does it with the default receive
             timeout.
 
             @return map of ids and (std) shared pointers to BaseServo instances

--- a/wscript
+++ b/wscript
@@ -18,6 +18,7 @@ def options(opt):
     #opt.add_option('--arm', action='store_true', help='enable arm cross-compilation', dest='arm')
 
     opt.recurse('src/tools')
+    opt.recurse('src/tests')
 
 
 def configure(conf):
@@ -25,6 +26,7 @@ def configure(conf):
     conf.env['CXXFLAGS'] = '-D_REENTRANT -Wall -finline-functions -Wno-inline  -fPIC -O3 -std=c++11 -ftemplate-depth-128 -Wno-sign-compare'.split(' ')
 
     conf.recurse('src/tools')
+    conf.recurse('src/tests')
 
     # if conf.options.arm:
     #     conf.setenv('arm', conf.env)
@@ -39,6 +41,7 @@ def configure(conf):
 def build(bld):
     bld.recurse('src/demos')
     bld.recurse('src/tools')
+    bld.recurse('src/tests')
 
     # if ('arm' in bld.all_envs) and (bld.all_envs['arm']['ENABLE_ARM'] is True):
     #     print "arm enabled"

--- a/wscript
+++ b/wscript
@@ -15,7 +15,7 @@ blddir = 'build'
 
 def options(opt):
     opt.load('compiler_cxx')
-    #opt.add_option('--arm', action='store_true', help='enable arm cross-compilation', dest='arm')
+    opt.add_option('--tests', action='store_true', help='compile tests or not', dest='tests')
 
     opt.recurse('src/tools')
     # opt.recurse('src/tests')
@@ -28,25 +28,14 @@ def configure(conf):
     conf.recurse('src/tools')
     # conf.recurse('src/tests')
 
-    # if conf.options.arm:
-    #     conf.setenv('arm', conf.env)
-    #     conf.env['ENABLE_ARM'] = True
-    #     conf.load('cross_arm', tooldir='waf_tools')
-    #     conf.find_arm_cc()
-    #     conf.find_arm_cxx_cpp()
-    #     conf.env['CXXFLAGS'] = '-D_REENTRANT -DDBG_ENABLED -Wall -O3 -ftemplate-depth-128 -Wno-sign-compare'
     print 'CXXFLAGS:' + str(conf.env['CXXFLAGS'])
 
 
 def build(bld):
     bld.recurse('src/demos')
     bld.recurse('src/tools')
-    # bld.recurse('src/tests')
-
-    # if ('arm' in bld.all_envs) and (bld.all_envs['arm']['ENABLE_ARM'] is True):
-    #     print "arm enabled"
-    #     for obj in copy.copy(bld.all_task_gen):
-    #         obj.clone('arm')
+    if bld.options.tests:
+        bld.recurse('src/tests')
 
     p = bld.srcnode.abspath() + '/src/dynamixel/'
 

--- a/wscript
+++ b/wscript
@@ -18,7 +18,7 @@ def options(opt):
     #opt.add_option('--arm', action='store_true', help='enable arm cross-compilation', dest='arm')
 
     opt.recurse('src/tools')
-    opt.recurse('src/tests')
+    # opt.recurse('src/tests')
 
 
 def configure(conf):
@@ -26,7 +26,7 @@ def configure(conf):
     conf.env['CXXFLAGS'] = '-D_REENTRANT -Wall -finline-functions -Wno-inline  -fPIC -O3 -std=c++11 -ftemplate-depth-128 -Wno-sign-compare'.split(' ')
 
     conf.recurse('src/tools')
-    conf.recurse('src/tests')
+    # conf.recurse('src/tests')
 
     # if conf.options.arm:
     #     conf.setenv('arm', conf.env)
@@ -41,7 +41,7 @@ def configure(conf):
 def build(bld):
     bld.recurse('src/demos')
     bld.recurse('src/tools')
-    bld.recurse('src/tests')
+    # bld.recurse('src/tests')
 
     # if ('arm' in bld.all_envs) and (bld.all_envs['arm']['ENABLE_ARM'] is True):
     #     print "arm enabled"


### PR DESCRIPTION
These modifications introduce a detection of the header for incoming messages. The goal is to better cope with the occasional perturbation we could observe on the bus.

To do so, as long as the incoming data does not match that of a packet header, it is ignored.

Also, checksum mismatch now only causes an exception if the user asks for it (through an attribute of the USB2Dynamixel class (a.k.a. controller or serial interface).

This code has been tested for protocol 1 and 2 in a simulated communication and for protocol 1 with real actuators.

Should we still have issues after these changes, we can consider the modification proposed in #26 .

@costashatz @jbmouret comments are welcome to check for bad design or obvious errors.