### PR TITLE
fix address for control gains for Dynamixel Pro

### DIFF
--- a/src/dynamixel/servos/pro_h42_20_s300.hpp
+++ b/src/dynamixel/servos/pro_h42_20_s300.hpp
@@ -60,9 +60,9 @@ namespace dynamixel {
                 typedef uint8_t led_g_t;
                 static const protocol_t::address_t led_b = 565;
                 typedef uint8_t led_b_t;
-                static const protocol_t::address_t velocity_i_gain = 26;
+                static const protocol_t::address_t velocity_i_gain = 586;
                 typedef uint16_t velocity_i_gain_t;
-                static const protocol_t::address_t velocity_p_gain = 27;
+                static const protocol_t::address_t velocity_p_gain = 588;
                 typedef uint16_t velocity_p_gain_t;
                 static const protocol_t::address_t position_p_gain = 594;
                 typedef uint16_t position_p_gain_t;

--- a/src/dynamixel/servos/pro_h42_20_s300.hpp
+++ b/src/dynamixel/servos/pro_h42_20_s300.hpp
@@ -64,7 +64,7 @@ namespace dynamixel {
                 typedef uint16_t velocity_i_gain_t;
                 static const protocol_t::address_t velocity_p_gain = 27;
                 typedef uint16_t velocity_p_gain_t;
-                static const protocol_t::address_t position_p_gain = 28;
+                static const protocol_t::address_t position_p_gain = 594;
                 typedef uint16_t position_p_gain_t;
                 static const protocol_t::address_t goal_position = 596;
                 typedef int32_t goal_position_t;

--- a/src/dynamixel/servos/pro_h54_100_s500.hpp
+++ b/src/dynamixel/servos/pro_h54_100_s500.hpp
@@ -60,9 +60,9 @@ namespace dynamixel {
                 typedef uint8_t led_g_t;
                 static const protocol_t::address_t led_b = 565;
                 typedef uint8_t led_b_t;
-                static const protocol_t::address_t velocity_i_gain = 26;
+                static const protocol_t::address_t velocity_i_gain = 586;
                 typedef uint16_t velocity_i_gain_t;
-                static const protocol_t::address_t velocity_p_gain = 27;
+                static const protocol_t::address_t velocity_p_gain = 588;
                 typedef uint16_t velocity_p_gain_t;
                 static const protocol_t::address_t position_p_gain = 594;
                 typedef uint16_t position_p_gain_t;

--- a/src/dynamixel/servos/pro_h54_100_s500.hpp
+++ b/src/dynamixel/servos/pro_h54_100_s500.hpp
@@ -64,7 +64,7 @@ namespace dynamixel {
                 typedef uint16_t velocity_i_gain_t;
                 static const protocol_t::address_t velocity_p_gain = 27;
                 typedef uint16_t velocity_p_gain_t;
-                static const protocol_t::address_t position_p_gain = 28;
+                static const protocol_t::address_t position_p_gain = 594;
                 typedef uint16_t position_p_gain_t;
                 static const protocol_t::address_t goal_position = 596;
                 typedef int32_t goal_position_t;

--- a/src/dynamixel/servos/pro_h54_200_s500.hpp
+++ b/src/dynamixel/servos/pro_h54_200_s500.hpp
@@ -60,9 +60,9 @@ namespace dynamixel {
                 typedef uint8_t led_g_t;
                 static const protocol_t::address_t led_b = 565;
                 typedef uint8_t led_b_t;
-                static const protocol_t::address_t velocity_i_gain = 26;
+                static const protocol_t::address_t velocity_i_gain = 586;
                 typedef uint16_t velocity_i_gain_t;
-                static const protocol_t::address_t velocity_p_gain = 27;
+                static const protocol_t::address_t velocity_p_gain = 588;
                 typedef uint16_t velocity_p_gain_t;
                 static const protocol_t::address_t position_p_gain = 594;
                 typedef uint16_t position_p_gain_t;

--- a/src/dynamixel/servos/pro_h54_200_s500.hpp
+++ b/src/dynamixel/servos/pro_h54_200_s500.hpp
@@ -64,7 +64,7 @@ namespace dynamixel {
                 typedef uint16_t velocity_i_gain_t;
                 static const protocol_t::address_t velocity_p_gain = 27;
                 typedef uint16_t velocity_p_gain_t;
-                static const protocol_t::address_t position_p_gain = 28;
+                static const protocol_t::address_t position_p_gain = 594;
                 typedef uint16_t position_p_gain_t;
                 static const protocol_t::address_t goal_position = 596;
                 typedef int32_t goal_position_t;

--- a/src/dynamixel/servos/pro_l42_10_s300.hpp
+++ b/src/dynamixel/servos/pro_l42_10_s300.hpp
@@ -62,7 +62,7 @@ namespace dynamixel {
                 typedef uint16_t velocity_i_gain_t;
                 static const protocol_t::address_t velocity_p_gain = 27;
                 typedef uint16_t velocity_p_gain_t;
-                static const protocol_t::address_t position_p_gain = 28;
+                static const protocol_t::address_t position_p_gain = 594;
                 typedef uint16_t position_p_gain_t;
                 static const protocol_t::address_t goal_position = 596;
                 typedef int32_t goal_position_t;

--- a/src/dynamixel/servos/pro_l42_10_s300.hpp
+++ b/src/dynamixel/servos/pro_l42_10_s300.hpp
@@ -58,9 +58,9 @@ namespace dynamixel {
                 typedef uint8_t led_g_t;
                 static const protocol_t::address_t led_b = 565;
                 typedef uint8_t led_b_t;
-                static const protocol_t::address_t velocity_i_gain = 26;
+                static const protocol_t::address_t velocity_i_gain = 586;
                 typedef uint16_t velocity_i_gain_t;
-                static const protocol_t::address_t velocity_p_gain = 27;
+                static const protocol_t::address_t velocity_p_gain = 588;
                 typedef uint16_t velocity_p_gain_t;
                 static const protocol_t::address_t position_p_gain = 594;
                 typedef uint16_t position_p_gain_t;

--- a/src/dynamixel/servos/pro_l54_30_s400.hpp
+++ b/src/dynamixel/servos/pro_l54_30_s400.hpp
@@ -60,9 +60,9 @@ namespace dynamixel {
                 typedef uint8_t led_g_t;
                 static const protocol_t::address_t led_b = 565;
                 typedef uint8_t led_b_t;
-                static const protocol_t::address_t velocity_i_gain = 26;
+                static const protocol_t::address_t velocity_i_gain = 586;
                 typedef uint16_t velocity_i_gain_t;
-                static const protocol_t::address_t velocity_p_gain = 27;
+                static const protocol_t::address_t velocity_p_gain = 588;
                 typedef uint16_t velocity_p_gain_t;
                 static const protocol_t::address_t position_p_gain = 594;
                 typedef uint16_t position_p_gain_t;

--- a/src/dynamixel/servos/pro_l54_30_s400.hpp
+++ b/src/dynamixel/servos/pro_l54_30_s400.hpp
@@ -64,7 +64,7 @@ namespace dynamixel {
                 typedef uint16_t velocity_i_gain_t;
                 static const protocol_t::address_t velocity_p_gain = 27;
                 typedef uint16_t velocity_p_gain_t;
-                static const protocol_t::address_t position_p_gain = 28;
+                static const protocol_t::address_t position_p_gain = 594;
                 typedef uint16_t position_p_gain_t;
                 static const protocol_t::address_t goal_position = 596;
                 typedef int32_t goal_position_t;

--- a/src/dynamixel/servos/pro_l54_30_s500.hpp
+++ b/src/dynamixel/servos/pro_l54_30_s500.hpp
@@ -60,9 +60,9 @@ namespace dynamixel {
                 typedef uint8_t led_g_t;
                 static const protocol_t::address_t led_b = 565;
                 typedef uint8_t led_b_t;
-                static const protocol_t::address_t velocity_i_gain = 26;
+                static const protocol_t::address_t velocity_i_gain = 586;
                 typedef uint16_t velocity_i_gain_t;
-                static const protocol_t::address_t velocity_p_gain = 27;
+                static const protocol_t::address_t velocity_p_gain = 588;
                 typedef uint16_t velocity_p_gain_t;
                 static const protocol_t::address_t position_p_gain = 594;
                 typedef uint16_t position_p_gain_t;

--- a/src/dynamixel/servos/pro_l54_30_s500.hpp
+++ b/src/dynamixel/servos/pro_l54_30_s500.hpp
@@ -64,7 +64,7 @@ namespace dynamixel {
                 typedef uint16_t velocity_i_gain_t;
                 static const protocol_t::address_t velocity_p_gain = 27;
                 typedef uint16_t velocity_p_gain_t;
-                static const protocol_t::address_t position_p_gain = 28;
+                static const protocol_t::address_t position_p_gain = 594;
                 typedef uint16_t position_p_gain_t;
                 static const protocol_t::address_t goal_position = 596;
                 typedef int32_t goal_position_t;

--- a/src/dynamixel/servos/pro_l54_50_s290.hpp
+++ b/src/dynamixel/servos/pro_l54_50_s290.hpp
@@ -60,9 +60,9 @@ namespace dynamixel {
                 typedef uint8_t led_g_t;
                 static const protocol_t::address_t led_b = 565;
                 typedef uint8_t led_b_t;
-                static const protocol_t::address_t velocity_i_gain = 26;
+                static const protocol_t::address_t velocity_i_gain = 586;
                 typedef uint16_t velocity_i_gain_t;
-                static const protocol_t::address_t velocity_p_gain = 27;
+                static const protocol_t::address_t velocity_p_gain = 588;
                 typedef uint16_t velocity_p_gain_t;
                 static const protocol_t::address_t position_p_gain = 594;
                 typedef uint16_t position_p_gain_t;

--- a/src/dynamixel/servos/pro_l54_50_s290.hpp
+++ b/src/dynamixel/servos/pro_l54_50_s290.hpp
@@ -64,7 +64,7 @@ namespace dynamixel {
                 typedef uint16_t velocity_i_gain_t;
                 static const protocol_t::address_t velocity_p_gain = 27;
                 typedef uint16_t velocity_p_gain_t;
-                static const protocol_t::address_t position_p_gain = 28;
+                static const protocol_t::address_t position_p_gain = 594;
                 typedef uint16_t position_p_gain_t;
                 static const protocol_t::address_t goal_position = 596;
                 typedef int32_t goal_position_t;

--- a/src/dynamixel/servos/pro_l54_50_s500.hpp
+++ b/src/dynamixel/servos/pro_l54_50_s500.hpp
@@ -60,9 +60,9 @@ namespace dynamixel {
                 typedef uint8_t led_g_t;
                 static const protocol_t::address_t led_b = 565;
                 typedef uint8_t led_b_t;
-                static const protocol_t::address_t velocity_i_gain = 26;
+                static const protocol_t::address_t velocity_i_gain = 586;
                 typedef uint16_t velocity_i_gain_t;
-                static const protocol_t::address_t velocity_p_gain = 27;
+                static const protocol_t::address_t velocity_p_gain = 588;
                 typedef uint16_t velocity_p_gain_t;
                 static const protocol_t::address_t position_p_gain = 594;
                 typedef uint16_t position_p_gain_t;

--- a/src/dynamixel/servos/pro_l54_50_s500.hpp
+++ b/src/dynamixel/servos/pro_l54_50_s500.hpp
@@ -64,7 +64,7 @@ namespace dynamixel {
                 typedef uint16_t velocity_i_gain_t;
                 static const protocol_t::address_t velocity_p_gain = 27;
                 typedef uint16_t velocity_p_gain_t;
-                static const protocol_t::address_t position_p_gain = 28;
+                static const protocol_t::address_t position_p_gain = 594;
                 typedef uint16_t position_p_gain_t;
                 static const protocol_t::address_t goal_position = 596;
                 typedef int32_t goal_position_t;

--- a/src/dynamixel/servos/pro_m42_10_s260.hpp
+++ b/src/dynamixel/servos/pro_m42_10_s260.hpp
@@ -60,9 +60,9 @@ namespace dynamixel {
                 typedef uint8_t led_g_t;
                 static const protocol_t::address_t led_b = 565;
                 typedef uint8_t led_b_t;
-                static const protocol_t::address_t velocity_i_gain = 26;
+                static const protocol_t::address_t velocity_i_gain = 586;
                 typedef uint16_t velocity_i_gain_t;
-                static const protocol_t::address_t velocity_p_gain = 27;
+                static const protocol_t::address_t velocity_p_gain = 588;
                 typedef uint16_t velocity_p_gain_t;
                 static const protocol_t::address_t position_p_gain = 594;
                 typedef uint16_t position_p_gain_t;

--- a/src/dynamixel/servos/pro_m42_10_s260.hpp
+++ b/src/dynamixel/servos/pro_m42_10_s260.hpp
@@ -64,7 +64,7 @@ namespace dynamixel {
                 typedef uint16_t velocity_i_gain_t;
                 static const protocol_t::address_t velocity_p_gain = 27;
                 typedef uint16_t velocity_p_gain_t;
-                static const protocol_t::address_t position_p_gain = 28;
+                static const protocol_t::address_t position_p_gain = 594;
                 typedef uint16_t position_p_gain_t;
                 static const protocol_t::address_t goal_position = 596;
                 typedef int32_t goal_position_t;

--- a/src/dynamixel/servos/pro_m54_40_s250.hpp
+++ b/src/dynamixel/servos/pro_m54_40_s250.hpp
@@ -60,9 +60,9 @@ namespace dynamixel {
                 typedef uint8_t led_g_t;
                 static const protocol_t::address_t led_b = 565;
                 typedef uint8_t led_b_t;
-                static const protocol_t::address_t velocity_i_gain = 26;
+                static const protocol_t::address_t velocity_i_gain = 586;
                 typedef uint16_t velocity_i_gain_t;
-                static const protocol_t::address_t velocity_p_gain = 27;
+                static const protocol_t::address_t velocity_p_gain = 588;
                 typedef uint16_t velocity_p_gain_t;
                 static const protocol_t::address_t position_p_gain = 594;
                 typedef uint16_t position_p_gain_t;

--- a/src/dynamixel/servos/pro_m54_40_s250.hpp
+++ b/src/dynamixel/servos/pro_m54_40_s250.hpp
@@ -64,7 +64,7 @@ namespace dynamixel {
                 typedef uint16_t velocity_i_gain_t;
                 static const protocol_t::address_t velocity_p_gain = 27;
                 typedef uint16_t velocity_p_gain_t;
-                static const protocol_t::address_t position_p_gain = 28;
+                static const protocol_t::address_t position_p_gain = 594;
                 typedef uint16_t position_p_gain_t;
                 static const protocol_t::address_t goal_position = 596;
                 typedef int32_t goal_position_t;

--- a/src/dynamixel/servos/pro_m54_60_s250.hpp
+++ b/src/dynamixel/servos/pro_m54_60_s250.hpp
@@ -60,9 +60,9 @@ namespace dynamixel {
                 typedef uint8_t led_g_t;
                 static const protocol_t::address_t led_b = 565;
                 typedef uint8_t led_b_t;
-                static const protocol_t::address_t velocity_i_gain = 26;
+                static const protocol_t::address_t velocity_i_gain = 586;
                 typedef uint16_t velocity_i_gain_t;
-                static const protocol_t::address_t velocity_p_gain = 27;
+                static const protocol_t::address_t velocity_p_gain = 588;
                 typedef uint16_t velocity_p_gain_t;
                 static const protocol_t::address_t position_p_gain = 594;
                 typedef uint16_t position_p_gain_t;

--- a/src/dynamixel/servos/pro_m54_60_s250.hpp
+++ b/src/dynamixel/servos/pro_m54_60_s250.hpp
@@ -64,7 +64,7 @@ namespace dynamixel {
                 typedef uint16_t velocity_i_gain_t;
                 static const protocol_t::address_t velocity_p_gain = 27;
                 typedef uint16_t velocity_p_gain_t;
-                static const protocol_t::address_t position_p_gain = 28;
+                static const protocol_t::address_t position_p_gain = 594;
                 typedef uint16_t position_p_gain_t;
                 static const protocol_t::address_t goal_position = 596;
                 typedef int32_t goal_position_t;


### PR DESCRIPTION
It seems that an error slipped in the control tables for all actuators of the Pro family. I corrected the addresses according to the official documentation [1] [2].

[1]: http://support.robotis.com/en/product/actuator/dynamixel_pro/dynamixelpro/control_table.htm
[2]: http://support.robotis.com/en/product/actuator/dynamixel_pro/dynamixelpro/control_table_l42.htm