### PR TITLE
Fix speed limits for Protocol 2

### DIFF
--- a/src/dynamixel/servos/protocol_specific_packets.hpp
+++ b/src/dynamixel/servos/protocol_specific_packets.hpp
@@ -166,7 +166,7 @@ namespace dynamixel {
                 int32_t speed_ticks = round(60 * rad_per_s / (two_pi * ct_t::rpm_per_tick));
 
                 // Check that desired speed is within the actuator's bounds
-                if (!(speed_ticks >= ct_t::min_goal_speed && speed_ticks <= ct_t::max_goal_speed)) {
+                if (!(abs(speed_ticks) <= ct_t::max_goal_speed)) {
                     double min_goal_speed = ct_t::min_goal_speed * ct_t::rpm_per_tick * two_pi / 60;
                     double max_goal_speed = ct_t::max_goal_speed * ct_t::rpm_per_tick * two_pi / 60;
                     throw errors::ServoLimitError(id, min_goal_speed, max_goal_speed, rad_per_s, "speed (rad/s)");


### PR DESCRIPTION
For the Pro L42, the value ct_t::min_goal_speed does not represent the lowest possible speed value for the actuator. So, I moved to checking the absolute of the speed ticks. It should still work as the range of values for all other dynamixel Pro is symmetrical.