### PR TITLE
Auto detect of selected IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## July, 13th 2017
+
+- [API change] (addition) `auto_detect` `and auto_detect_map` now have an optional (function overload) second argument: a `std::vector` of `Protocol::id_t` (servo ID); if this argument is provided, the library will only scan for the desired IDs
+- [Improvement] command line utility uses the above functionality to dramatically reduce response time when IDs are provided.
+
 ## Current branch
 
 - [Deprecation] removed method `get_goal_speed_angle` that only duplicated `get_moving_speed` and brought nothing

--- a/src/dynamixel/auto_detect.hpp
+++ b/src/dynamixel/auto_detect.hpp
@@ -79,7 +79,9 @@ namespace dynamixel {
         @return vector of actuators
     **/
     template <typename Protocol, typename Controller>
-    inline std::vector<std::shared_ptr<servos::BaseServo<Protocol>>> auto_detect(const Controller& controller)
+    inline std::vector<std::shared_ptr<servos::BaseServo<Protocol>>> auto_detect(
+        const Controller& controller,
+        std::vector<Protocol::id_t>& ids = null) // FIXME: how to make empty vector reference ?
     {
         // vector of actuators returned by this function
         std::vector<std::shared_ptr<servos::BaseServo<Protocol>>> res;
@@ -88,8 +90,13 @@ namespace dynamixel {
         // get_servo (protocol 1 or 2)
         typename Protocol::address_t selected_protocol = 0;
 
+        if (ids == null) {
+            ids = range(0, Protocol::broadcast_id); // FIXME
+            // FIXME: if only it could work like a python generator
+        }
+
         // search through each possible device ID
-        for (typename Protocol::id_t id = 0; id < Protocol::broadcast_id; id++) {
+        for (typename Protocol::id_t id : ids) {
             try {
                 // Send a ping. If it is answered, read the actuator model and
                 // instanciate a class of the correct type
@@ -111,6 +118,15 @@ namespace dynamixel {
         }
 
         return res;
+    }
+
+    // FIXME : how to make this method be of vector type ?
+    template <class T>
+    T range_generator(T lower, T upper)
+    {
+        static T current = lower;
+        if (current < upper)
+            reutrn current++; // FIXME : or ++current ?
     }
 
     /** Auto-detect all connected actuators using a given protocol.
@@ -163,6 +179,6 @@ namespace dynamixel {
 
         return res;
     }
-}
+} // namespace dynamixel
 
 #endif

--- a/src/tools/command_line_utility.hpp
+++ b/src/tools/command_line_utility.hpp
@@ -415,7 +415,7 @@ namespace dynamixel {
 
         void change_baudrate(const std::vector<id_t>& ids, unsigned int baudrate)
         {
-            _dyn_util.detect_servos();
+            _dyn_util.detect_servos(ids);
 
             for (auto id : ids) {
                 _dyn_util.change_baudrate(id, baudrate);
@@ -429,7 +429,7 @@ namespace dynamixel {
 
         void factory_reset(const std::vector<id_t>& ids)
         {
-            _dyn_util.detect_servos();
+            _dyn_util.detect_servos(ids);
 
             for (auto id : ids) {
                 _dyn_util.factory_reset(id);
@@ -444,11 +444,11 @@ namespace dynamixel {
         void position(const std::vector<id_t>& ids, const std::vector<double>& angles)
         {
             if (angles.size() == 1) {
-                _dyn_util.detect_servos();
+                _dyn_util.detect_servos(ids);
                 _dyn_util.set_angle(ids, angles.at(0));
             }
             else if (ids.size() == angles.size()) {
-                _dyn_util.detect_servos();
+                _dyn_util.detect_servos(ids);
                 _dyn_util.set_angle(ids, angles);
             }
             else
@@ -478,7 +478,7 @@ namespace dynamixel {
             if (ids.size() == 0)
                 return;
 
-            _dyn_util.detect_servos();
+            _dyn_util.detect_servos(ids);
 
             std::vector<double> positions;
             positions = _dyn_util.get_angle(ids);
@@ -506,11 +506,11 @@ namespace dynamixel {
             bool wheel_mode = false)
         {
             if (speeds.size() == 1) {
-                _dyn_util.detect_servos();
+                _dyn_util.detect_servos(ids);
                 _dyn_util.set_speed(ids, speeds.at(0), wheel_mode);
             }
             else if (ids.size() == speeds.size()) {
-                _dyn_util.detect_servos();
+                _dyn_util.detect_servos(ids);
                 _dyn_util.set_speed(ids, speeds, wheel_mode);
             }
             else
@@ -540,7 +540,7 @@ namespace dynamixel {
             if (ids.size() == 0)
                 return;
 
-            _dyn_util.detect_servos();
+            _dyn_util.detect_servos(ids);
 
             std::vector<double> speeds;
             speeds = _dyn_util.get_speed(ids);
@@ -567,7 +567,7 @@ namespace dynamixel {
 
         void torque_enable(const std::vector<id_t>& ids, bool enable = true)
         {
-            _dyn_util.detect_servos();
+            _dyn_util.detect_servos(ids);
 
             for (auto id : ids) {
                 _dyn_util.torque_enable(id, enable);
@@ -582,7 +582,7 @@ namespace dynamixel {
 
         void print_torque_enable(const std::vector<id_t>& ids)
         {
-            _dyn_util.detect_servos();
+            _dyn_util.detect_servos(ids);
             std::vector<bool> enabled = _dyn_util.get_torque_enable(ids);
 
             if (ids.size() == 1) {

--- a/src/tools/command_line_utility.hpp
+++ b/src/tools/command_line_utility.hpp
@@ -416,7 +416,7 @@ namespace dynamixel {
 
         void change_baudrate(const std::vector<id_t>& ids, unsigned int baudrate)
         {
-            _dyn_util.detect_servos();
+            _dyn_util.detect_servos(ids);
 
             for (auto id : ids) {
                 _dyn_util.change_baudrate(id, baudrate);
@@ -430,7 +430,7 @@ namespace dynamixel {
 
         void factory_reset(const std::vector<id_t>& ids)
         {
-            _dyn_util.detect_servos();
+            _dyn_util.detect_servos(ids);
 
             for (auto id : ids) {
                 _dyn_util.factory_reset(id);
@@ -445,11 +445,11 @@ namespace dynamixel {
         void position(const std::vector<id_t>& ids, const std::vector<double>& angles)
         {
             if (angles.size() == 1) {
-                _dyn_util.detect_servos();
+                _dyn_util.detect_servos(ids);
                 _dyn_util.set_angle(ids, angles.at(0));
             }
             else if (ids.size() == angles.size()) {
-                _dyn_util.detect_servos();
+                _dyn_util.detect_servos(ids);
                 _dyn_util.set_angle(ids, angles);
             }
             else
@@ -479,7 +479,7 @@ namespace dynamixel {
             if (ids.size() == 0)
                 return;
 
-            _dyn_util.detect_servos();
+            _dyn_util.detect_servos(ids);
 
             std::vector<double> positions;
             positions = _dyn_util.get_angle(ids);
@@ -507,11 +507,11 @@ namespace dynamixel {
             bool wheel_mode = false)
         {
             if (speeds.size() == 1) {
-                _dyn_util.detect_servos();
+                _dyn_util.detect_servos(ids);
                 _dyn_util.set_speed(ids, speeds.at(0), wheel_mode);
             }
             else if (ids.size() == speeds.size()) {
-                _dyn_util.detect_servos();
+                _dyn_util.detect_servos(ids);
                 _dyn_util.set_speed(ids, speeds, wheel_mode);
             }
             else
@@ -541,7 +541,7 @@ namespace dynamixel {
             if (ids.size() == 0)
                 return;
 
-            _dyn_util.detect_servos();
+            _dyn_util.detect_servos(ids);
 
             std::vector<double> speeds;
             speeds = _dyn_util.get_speed(ids);
@@ -568,7 +568,7 @@ namespace dynamixel {
 
         void torque_enable(const std::vector<id_t>& ids, bool enable = true)
         {
-            _dyn_util.detect_servos();
+            _dyn_util.detect_servos(ids);
 
             for (auto id : ids) {
                 _dyn_util.torque_enable(id, enable);
@@ -583,7 +583,7 @@ namespace dynamixel {
 
         void print_torque_enable(const std::vector<id_t>& ids)
         {
-            _dyn_util.detect_servos();
+            _dyn_util.detect_servos(ids);
             std::vector<bool> enabled = _dyn_util.get_torque_enable(ids);
 
             if (ids.size() == 1) {

--- a/src/tools/command_line_utility.hpp
+++ b/src/tools/command_line_utility.hpp
@@ -600,8 +600,7 @@ namespace dynamixel {
             }
         }
 
-        void
-        print_torque_enable()
+        void print_torque_enable()
         {
             _dyn_util.detect_servos();
             std::pair<std::vector<id_t>, std::vector<bool>> response
@@ -653,6 +652,6 @@ namespace dynamixel {
                 _dyn_util.set_angle(ids, angle);
         }
     };
-}
+} // namespace dynamixel
 
 #endif

--- a/src/tools/command_line_utility.hpp
+++ b/src/tools/command_line_utility.hpp
@@ -601,8 +601,7 @@ namespace dynamixel {
             }
         }
 
-        void
-        print_torque_enable()
+        void print_torque_enable()
         {
             _dyn_util.detect_servos();
             std::pair<std::vector<id_t>, std::vector<bool>> response
@@ -654,6 +653,6 @@ namespace dynamixel {
                 _dyn_util.set_angle(ids, angle);
         }
     };
-}
+} // namespace dynamixel
 
 #endif

--- a/src/tools/command_line_utility.hpp
+++ b/src/tools/command_line_utility.hpp
@@ -28,8 +28,9 @@ namespace dynamixel {
             @throws dynamixel::errors:Error if an issue was met while attempting
             to open the serial interface
         **/
-        CommandLineUtility(const std::string& name, int baudrate = B115200, double recv_timeout = 0.1)
-            : _dyn_util(name, baudrate, recv_timeout)
+        CommandLineUtility(const std::string& name, int baudrate = B115200,
+            double recv_timeout = 0.1, double scan_timeout = 0.05)
+            : _dyn_util(name, baudrate, recv_timeout, scan_timeout)
         {
         }
 

--- a/src/tools/dynamixel.cpp
+++ b/src/tools/dynamixel.cpp
@@ -266,7 +266,7 @@ int main(int argc, char** argv)
             "values")
         ("timeout,t", po::value<double>(&timeout)->default_value(0.02),
             "timeout for the reception of data packets")
-        ("scan-timeout", po::value<double>(&scan_timeout)->default_value(0.02),
+        ("scan-timeout", po::value<double>(&scan_timeout)->default_value(0.05),
             "timeout for the scanning, to search for available servos")
         ("id", po::value<std::vector<id_t>>()->multitoken(),
             "one or more IDs of devices")

--- a/src/tools/dynamixel.cpp
+++ b/src/tools/dynamixel.cpp
@@ -244,7 +244,7 @@ int main(int argc, char** argv)
     // Parameters for serial communication
     std::string port;
     int baudrate = 0, posix_baudrate = 0;
-    float timeout;
+    double timeout, scan_timeout;
 
     // Definition of command line options
     // ==================================
@@ -264,8 +264,10 @@ int main(int argc, char** argv)
             "EXAMPLE: -b 115200\n"
             "See the help for the `change-baudrate` command for the accepted "
             "values")
-        ("timeout,t", po::value<float>(&timeout)->default_value(0.02),
+        ("timeout,t", po::value<double>(&timeout)->default_value(0.02),
             "timeout for the reception of data packets")
+        ("scan-timeout", po::value<double>(&scan_timeout)->default_value(0.02),
+            "timeout for the scanning, to search for available servos")
         ("id", po::value<std::vector<id_t>>()->multitoken(),
             "one or more IDs of devices")
         ("angle", po::value<std::vector<double>>()->multitoken(),
@@ -356,7 +358,8 @@ int main(int argc, char** argv)
     // Opening serial connexion and executing the user's command
     // =========================================================
     try {
-        CommandLineUtility<Protocol> command_line(port, posix_baudrate, timeout);
+        CommandLineUtility<Protocol> command_line(port, posix_baudrate, timeout,
+            scan_timeout);
         command_line.select_command(vm);
     }
     catch (errors::Error e) {

--- a/src/tools/utility.hpp
+++ b/src/tools/utility.hpp
@@ -27,11 +27,16 @@ namespace dynamixel {
         typedef unsigned short id_t;
 
         /**
+
+            @param scan_timeout (default 0.05) set a special listening timeout;
+                will only apply for this detection process
+
             @throws dynamixel::errors:Error if an issue was met while attempting
             to open the serial interface
         **/
-        Utility(const std::string& name, int baudrate = B115200, double recv_timeout = 0.1)
-            : _serial_interface(name, baudrate, recv_timeout), _scanned(false)
+        Utility(const std::string& name, int baudrate = B115200,
+            double recv_timeout = 0.1, double scan_timeout = 0.05)
+            : _serial_interface(name, baudrate, recv_timeout), _scanned(false), _scan_timeout(scan_timeout)
         {
         }
 
@@ -43,17 +48,14 @@ namespace dynamixel {
             interface and talking at a given baudrate. Also, they have to speak
             the same protocol you use to talk to them.
 
-            @param scan_timeout (default 0.01) set a special listening timeout;
-                will only apply for this detection process
-
             @throws dynamixel::error::UnpackError from auto_detect_map
             @throws dynamixel::error:Error from auto_detect_map
 
         **/
-        void detect_servos(double scan_timeout = 0.01)
+        void detect_servos()
         {
             double original_timeout = _serial_interface.recv_timeout();
-            _serial_interface.set_recv_timeout(scan_timeout);
+            _serial_interface.set_recv_timeout(_scan_timeout);
 
             _servos = auto_detect_map<Protocol>(_serial_interface);
             _scanned = true;
@@ -779,7 +781,8 @@ namespace dynamixel {
         std::map<typename Protocol::id_t, std::shared_ptr<BaseServo<Protocol>>>
             _servos;
         bool _scanned;
+        double _scan_timeout;
     };
-}
+} // namespace dynamixel
 
 #endif

--- a/src/tools/utility.hpp
+++ b/src/tools/utility.hpp
@@ -63,6 +63,34 @@ namespace dynamixel {
             _serial_interface.set_recv_timeout(original_timeout);
         }
 
+        /** Detect the connected servos on the bus.
+            These servos are then stored internally and you can use the other
+            methods to send them orders or get data about them.
+
+            This method looks only for the servos requested through the parameter ids
+
+            @see detect_servos(double scan_timeout = 0.01)
+
+            @param ids vector of servo ID to be searched for
+            @param scan_timeout (default 0.01) set a special listening timeout;
+                will only apply for this detection process
+
+            @throws dynamixel::error::UnpackError from auto_detect_map
+            @throws dynamixel::error:Error from auto_detect_map
+
+        **/
+        void detect_servos(const std::vector<id_t>& ids, double scan_timeout = 0.01)
+        {
+            double original_timeout = _serial_interface.recv_timeout();
+            _serial_interface.set_recv_timeout(scan_timeout);
+
+            std::vector<typename Protocol::id_t> ids_right_type(ids.begin(), ids.end());
+            _servos = auto_detect_map<Protocol>(_serial_interface, ids_right_type);
+            _scanned = true;
+
+            _serial_interface.set_recv_timeout(original_timeout);
+        }
+
         /** Return the connected actuators.
             If we didn't do a scanning yet, does it with the default receive
             timeout.

--- a/src/tools/utility.hpp
+++ b/src/tools/utility.hpp
@@ -61,6 +61,34 @@ namespace dynamixel {
             _serial_interface.set_recv_timeout(original_timeout);
         }
 
+        /** Detect the connected servos on the bus.
+            These servos are then stored internally and you can use the other
+            methods to send them orders or get data about them.
+
+            This method looks only for the servos requested through the parameter ids
+
+            @see detect_servos(double scan_timeout = 0.01)
+
+            @param ids vector of servo ID to be searched for
+            @param scan_timeout (default 0.01) set a special listening timeout;
+                will only apply for this detection process
+
+            @throws dynamixel::error::UnpackError from auto_detect_map
+            @throws dynamixel::error:Error from auto_detect_map
+
+        **/
+        void detect_servos(const std::vector<id_t>& ids, double scan_timeout = 0.01)
+        {
+            double original_timeout = _serial_interface.recv_timeout();
+            _serial_interface.set_recv_timeout(scan_timeout);
+
+            std::vector<typename Protocol::id_t> ids_right_type(ids.begin(), ids.end());
+            _servos = auto_detect_map<Protocol>(_serial_interface, ids_right_type);
+            _scanned = true;
+
+            _serial_interface.set_recv_timeout(original_timeout);
+        }
+
         /** Return the connected actuators.
             If we didn't do a scanning yet, does it with the default receive
             timeout.

--- a/src/tools/utility.hpp
+++ b/src/tools/utility.hpp
@@ -72,17 +72,15 @@ namespace dynamixel {
             @see detect_servos(double scan_timeout = 0.01)
 
             @param ids vector of servo ID to be searched for
-            @param scan_timeout (default 0.01) set a special listening timeout;
-                will only apply for this detection process
 
             @throws dynamixel::error::UnpackError from auto_detect_map
             @throws dynamixel::error:Error from auto_detect_map
 
         **/
-        void detect_servos(const std::vector<id_t>& ids, double scan_timeout = 0.01)
+        void detect_servos(const std::vector<id_t>& ids)
         {
             double original_timeout = _serial_interface.recv_timeout();
-            _serial_interface.set_recv_timeout(scan_timeout);
+            _serial_interface.set_recv_timeout(_scan_timeout);
 
             std::vector<typename Protocol::id_t> ids_right_type(ids.begin(), ids.end());
             _servos = auto_detect_map<Protocol>(_serial_interface, ids_right_type);

--- a/src/tools/utility.hpp
+++ b/src/tools/utility.hpp
@@ -808,6 +808,6 @@ namespace dynamixel {
             _servos;
         bool _scanned;
     };
-}
+} // namespace dynamixel
 
 #endif


### PR DESCRIPTION
This branch introduces the amazing feature that allows to select which servos we are looking for ! Thanks to this, the scan time of the command line utility can be dramatically reduced. I hope to introduce this in [dynamixel_control_hw](https://github.com/resibots/dynamixel_control_hw/) once this is merged.