### PR TITLE
Allow to change timeout for scanning of servos.

### DIFF
--- a/src/tools/command_line_utility.hpp
+++ b/src/tools/command_line_utility.hpp
@@ -28,8 +28,9 @@ namespace dynamixel {
             @throws dynamixel::errors:Error if an issue was met while attempting
             to open the serial interface
         **/
-        CommandLineUtility(const std::string& name, int baudrate = B115200, double recv_timeout = 0.1)
-            : _dyn_util(name, baudrate, recv_timeout)
+        CommandLineUtility(const std::string& name, int baudrate = B115200,
+            double recv_timeout = 0.1, double scan_timeout = 0.05)
+            : _dyn_util(name, baudrate, recv_timeout, scan_timeout)
         {
         }
 

--- a/src/tools/dynamixel.cpp
+++ b/src/tools/dynamixel.cpp
@@ -266,7 +266,7 @@ int main(int argc, char** argv)
             "values")
         ("timeout,t", po::value<double>(&timeout)->default_value(0.02),
             "timeout for the reception of data packets")
-        ("scan-timeout", po::value<double>(&scan_timeout)->default_value(0.02),
+        ("scan-timeout", po::value<double>(&scan_timeout)->default_value(0.05),
             "timeout for the scanning, to search for available servos")
         ("id", po::value<std::vector<id_t>>()->multitoken(),
             "one or more IDs of devices")

--- a/src/tools/dynamixel.cpp
+++ b/src/tools/dynamixel.cpp
@@ -244,7 +244,7 @@ int main(int argc, char** argv)
     // Parameters for serial communication
     std::string port;
     int baudrate = 0, posix_baudrate = 0;
-    float timeout;
+    double timeout, scan_timeout;
 
     // Definition of command line options
     // ==================================
@@ -264,8 +264,10 @@ int main(int argc, char** argv)
             "EXAMPLE: -b 115200\n"
             "See the help for the `change-baudrate` command for the accepted "
             "values")
-        ("timeout,t", po::value<float>(&timeout)->default_value(0.02),
+        ("timeout,t", po::value<double>(&timeout)->default_value(0.02),
             "timeout for the reception of data packets")
+        ("scan-timeout", po::value<double>(&scan_timeout)->default_value(0.02),
+            "timeout for the scanning, to search for available servos")
         ("id", po::value<std::vector<id_t>>()->multitoken(),
             "one or more IDs of devices")
         ("angle", po::value<std::vector<double>>()->multitoken(),
@@ -356,7 +358,8 @@ int main(int argc, char** argv)
     // Opening serial connexion and executing the user's command
     // =========================================================
     try {
-        CommandLineUtility<Protocol> command_line(port, posix_baudrate, timeout);
+        CommandLineUtility<Protocol> command_line(port, posix_baudrate, timeout,
+            scan_timeout);
         command_line.select_command(vm);
     }
     catch (errors::Error e) {

--- a/src/tools/utility.hpp
+++ b/src/tools/utility.hpp
@@ -27,11 +27,16 @@ namespace dynamixel {
         typedef unsigned short id_t;
 
         /**
+
+            @param scan_timeout (default 0.05) set a special listening timeout;
+                will only apply for this detection process
+
             @throws dynamixel::errors:Error if an issue was met while attempting
             to open the serial interface
         **/
-        Utility(const std::string& name, int baudrate = B115200, double recv_timeout = 0.1)
-            : _serial_interface(name, baudrate, recv_timeout), _scanned(false)
+        Utility(const std::string& name, int baudrate = B115200,
+            double recv_timeout = 0.1, double scan_timeout = 0.05)
+            : _serial_interface(name, baudrate, recv_timeout), _scanned(false), _scan_timeout(scan_timeout)
         {
         }
 
@@ -43,17 +48,14 @@ namespace dynamixel {
             interface and talking at a given baudrate. Also, they have to speak
             the same protocol you use to talk to them.
 
-            @param scan_timeout (default 0.01) set a special listening timeout;
-                will only apply for this detection process
-
             @throws dynamixel::error::UnpackError from auto_detect_map
             @throws dynamixel::error:Error from auto_detect_map
 
         **/
-        void detect_servos(double scan_timeout = 0.01)
+        void detect_servos()
         {
             double original_timeout = _serial_interface.recv_timeout();
-            _serial_interface.set_recv_timeout(scan_timeout);
+            _serial_interface.set_recv_timeout(_scan_timeout);
 
             _servos = auto_detect_map<Protocol>(_serial_interface);
             _scanned = true;
@@ -779,7 +781,8 @@ namespace dynamixel {
         std::map<typename Protocol::id_t, std::shared_ptr<BaseServo<Protocol>>>
             _servos;
         bool _scanned;
+        double _scan_timeout;
     };
-}
+} // namespace dynamixel
 
 #endif


### PR DESCRIPTION
In the command-line utility, most commands require that first the
available servos are searched on the bus. For faster search, a fixed,
small, timeout was used.

We observed that this value could bring problems for some serial
interfaces. Hence, it is now possible to manually override this timeout,
through the new option "-scan-timeout".

@jbmouret @costashatz please review and allow merging asap.