### PR TITLE
Improve exception class UnpackError, gives more info.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 - [Improvement] add information on the unit in error message for position and speed limit overflow
 - [Command line] allow to set timeout for the scan for connected servos
 - [Command line] catch exceptions raised by boost::program_options when improper options are used
+- [Improvement] the UnpackError tells the user how many bytes arrived and were expected

--- a/src/dynamixel/errors/unpack_error.hpp
+++ b/src/dynamixel/errors/unpack_error.hpp
@@ -11,11 +11,15 @@ namespace dynamixel {
     namespace errors {
         class UnpackError : public Error {
         public:
-            UnpackError(uint8_t protocol) : _protocol(protocol)
+            using size_type = std::vector<uint8_t>::size_type;
+            UnpackError(uint8_t protocol, size_type size, size_type expected_size)
+                : _protocol(protocol), _size(size), _expected_size(expected_size)
             {
                 std::stringstream err_message;
-                err_message << "Unpack: error while unpacking data in protocol: "
-                            << (int)_protocol;
+                err_message << "Unpack: error while unpacking data in protocol "
+                            << (int)_protocol << "; expected "
+                            << (int)_expected_size << " bytes and got "
+                            << (int)_size << " bytes.";
                 this->_msg = err_message.str();
             }
 
@@ -24,10 +28,21 @@ namespace dynamixel {
                 return _protocol;
             }
 
+            size_type size() const
+            {
+                return _size;
+            }
+
+            size_type expected_size() const
+            {
+                return _expected_size;
+            }
+
         private:
             uint8_t _protocol;
+            size_type _size, _expected_size;
         };
-    }
-}
+    } // namespace errors
+} // namespace dynamixel
 
 #endif

--- a/src/dynamixel/protocols/protocol1.hpp
+++ b/src/dynamixel/protocols/protocol1.hpp
@@ -112,8 +112,8 @@ namespace dynamixel {
 
             static void unpack_data(const std::vector<uint8_t>& packet, uint8_t& res)
             {
-                if (packet.size() == 0)
-                    throw errors::UnpackError(1, packet.size(), 0);
+                if (packet.size() != 1)
+                    throw errors::UnpackError(1, packet.size(), 1);
                 res = packet[0];
             }
 

--- a/src/dynamixel/protocols/protocol1.hpp
+++ b/src/dynamixel/protocols/protocol1.hpp
@@ -113,14 +113,14 @@ namespace dynamixel {
             static void unpack_data(const std::vector<uint8_t>& packet, uint8_t& res)
             {
                 if (packet.size() == 0)
-                    throw errors::UnpackError(1);
+                    throw errors::UnpackError(1, packet.size(), 0);
                 res = packet[0];
             }
 
             static void unpack_data(const std::vector<uint8_t>& packet, uint16_t& res)
             {
                 if (packet.size() != 2)
-                    throw errors::UnpackError(1);
+                    throw errors::UnpackError(1, packet.size(), 2);
                 res = (((uint16_t)packet[1]) << 8) | ((uint16_t)packet[0]);
             }
 
@@ -253,7 +253,7 @@ namespace dynamixel {
                 return ~checksum;
             }
         };
-    }
-}
+    } // namespace protocols
+} // namespace dynamixel
 
 #endif

--- a/src/dynamixel/protocols/protocol2.hpp
+++ b/src/dynamixel/protocols/protocol2.hpp
@@ -135,28 +135,28 @@ namespace dynamixel {
             static void unpack_data(const std::vector<uint8_t>& packet, uint8_t& res)
             {
                 if (packet.size() == 0)
-                    throw errors::UnpackError(2);
+                    throw errors::UnpackError(2, packet.size(), 0);
                 res = packet[0];
             }
 
             static void unpack_data(const std::vector<uint8_t>& packet, uint16_t& res)
             {
                 if (packet.size() != 2)
-                    throw errors::UnpackError(2);
+                    throw errors::UnpackError(2, packet.size(), 2);
                 res = (((uint16_t)packet[1]) << 8) | ((uint16_t)packet[0]);
             }
 
             static void unpack_data(const std::vector<uint8_t>& packet, uint32_t& res)
             {
                 if (packet.size() != 4)
-                    throw errors::UnpackError(2);
+                    throw errors::UnpackError(2, packet.size(), 4);
                 res = (((uint32_t)packet[3]) << 24) | (((uint32_t)packet[2]) << 16) | (((uint32_t)packet[1]) << 8) | ((uint32_t)packet[0]);
             }
 
             static void unpack_data(const std::vector<uint8_t>& packet, int32_t& res)
             {
                 if (packet.size() != 4)
-                    throw errors::UnpackError(2);
+                    throw errors::UnpackError(2, packet.size(), 4);
                 res = (((int32_t)packet[3]) << 24) | (((int32_t)packet[2]) << 16) | (((int32_t)packet[1]) << 8) | ((int32_t)packet[0]);
             }
 
@@ -318,7 +318,7 @@ namespace dynamixel {
                 return crc_accum;
             }
         };
-    }
-}
+    } // namespace protocols
+} // namespace dynamixel
 
 #endif

--- a/src/dynamixel/protocols/protocol2.hpp
+++ b/src/dynamixel/protocols/protocol2.hpp
@@ -134,8 +134,8 @@ namespace dynamixel {
 
             static void unpack_data(const std::vector<uint8_t>& packet, uint8_t& res)
             {
-                if (packet.size() == 0)
-                    throw errors::UnpackError(2, packet.size(), 0);
+                if (packet.size() != 1)
+                    throw errors::UnpackError(2, packet.size(), 1);
                 res = packet[0];
             }
 


### PR DESCRIPTION
Now this exception also tells how many bytes were needed/expected versus
how many actually arrived.

Since this exception is only meant to be raised from within the library, and since the API is not changed (only grown), I could not see any threat for the users of this library.