### PR TITLE
Operating mode as a scoped enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Current branch
 
+- [API change] the operating mode (wheel or joint) is now defined as a scoped enum, thus used like `dynamixel::OpertingMode::wheel`
 - [Deprecation] removed method `get_goal_speed_angle` that only duplicated `get_moving_speed` and brought nothing
 - [API change] renamed methods `reg_goal_speed_angle` and `set_goal_speed_angle` respectively to `reg_moving_speed_angle` and `set_moving_speed_angle`
 - [Improvement] add information on the unit in error message for position and speed limit overflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,4 @@
-## July, 13th 2017
-
-- [API change] (addition) `auto_detect` `and auto_detect_map` now have an optional (function overload) second argument: a `std::vector` of `Protocol::id_t` (servo ID); if this argument is provided, the library will only scan for the desired IDs
-- [Improvement] command line utility uses the above functionality to dramatically reduce response time when IDs are provided.
-
-## Current branch
-
+## March, 2nd 2018
 - [API change] the operating mode (wheel or joint) is now defined as a scoped enum, thus used like `dynamixel::OpertingMode::wheel`
 - [Deprecation] removed method `get_goal_speed_angle` that only duplicated `get_moving_speed` and brought nothing
 - [API change] renamed methods `reg_goal_speed_angle` and `set_goal_speed_angle` respectively to `reg_moving_speed_angle` and `set_moving_speed_angle`
@@ -12,3 +6,8 @@
 - [Command line] allow to set timeout for the scan for connected servos
 - [Command line] catch exceptions raised by boost::program_options when improper options are used
 - [Improvement] the UnpackError tells the user how many bytes arrived and were expected
+
+## July, 13th 2017
+
+- [API change] (addition) `auto_detect` `and auto_detect_map` now have an optional (function overload) second argument: a `std::vector` of `Protocol::id_t` (servo ID); if this argument is provided, the library will only scan for the desired IDs
+- [Improvement] command line utility uses the above functionality to dramatically reduce response time when IDs are provided.

--- a/src/dynamixel/auto_detect.hpp
+++ b/src/dynamixel/auto_detect.hpp
@@ -75,7 +75,7 @@ namespace dynamixel {
     inline std::shared_ptr<servos::BaseServo<Protocol>>
     find_servo(const Controller& controller, typename Protocol::id_t id)
     {
-        // Dummy variable used only to differenciate between the tow version of
+        // Dummy variable used only to differenciate between the two version of
         // get_servo (protocol 1 or 2)
         typename Protocol::address_t selected_protocol = 0;
 

--- a/src/dynamixel/instruction_packet.hpp
+++ b/src/dynamixel/instruction_packet.hpp
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <stdint.h>
+#include <cstddef> // for size-t
 
 namespace dynamixel {
     template <class Protocol>

--- a/src/dynamixel/instruction_packet.hpp
+++ b/src/dynamixel/instruction_packet.hpp
@@ -23,6 +23,6 @@ namespace dynamixel {
     protected:
         std::vector<uint8_t> _packet;
     };
-}
+} // namespace dynamixel
 
 #endif

--- a/src/dynamixel/servos/base_servo.hpp
+++ b/src/dynamixel/servos/base_servo.hpp
@@ -171,7 +171,7 @@ namespace dynamixel {
         protected:
             BaseServo() {}
         };
-    }
-}
+    } // namespace servos
+} // namespace dynamixel
 
 #endif

--- a/src/dynamixel/servos/base_servo.hpp
+++ b/src/dynamixel/servos/base_servo.hpp
@@ -26,14 +26,13 @@
     }
 
 namespace dynamixel {
+    enum class OperatingMode {
+        wheel,
+        joint,
+        multi_turn,
+        unknown
+    };
     namespace servos {
-        namespace cst {
-            enum OperatingMode {
-                wheel,
-                joint,
-                multi_turn
-            };
-        }
 
         template <typename Protocol>
         class BaseServo {
@@ -153,12 +152,12 @@ namespace dynamixel {
             // =================================================================
             // Speed-specific
 
-            virtual InstructionPacket<protocol_t> set_moving_speed_angle(double rad_per_s, cst::OperatingMode operating_mode = cst::joint) const
+            virtual InstructionPacket<protocol_t> set_moving_speed_angle(double rad_per_s, OperatingMode operating_mode = OperatingMode::joint) const
             {
                 throw errors::Error("set_moving_speed_angle not implemented in model");
             }
 
-            virtual InstructionPacket<protocol_t> reg_moving_speed_angle(double rad_per_s, cst::OperatingMode operating_mode = cst::joint) const
+            virtual InstructionPacket<protocol_t> reg_moving_speed_angle(double rad_per_s, OperatingMode operating_mode = OperatingMode::joint) const
             {
                 throw errors::Error("reg_moving_speed_angle not implemented in model");
             }

--- a/src/dynamixel/servos/protocol_specific_packets.hpp
+++ b/src/dynamixel/servos/protocol_specific_packets.hpp
@@ -35,7 +35,7 @@ namespace dynamixel {
             static inline InstructionPacket<P> set_moving_speed_angle(
                 typename P::id_t id,
                 double rad_per_s,
-                cst::OperatingMode operating_mode = cst::joint)
+                OperatingMode operating_mode = OperatingMode::joint)
             {
                 throw errors::Error("set_moving_speed_angle not implemented for this protocol");
             }
@@ -54,7 +54,7 @@ namespace dynamixel {
             static inline InstructionPacket<P> reg_moving_speed_angle(
                 typename P::id_t id,
                 double rad_per_s,
-                cst::OperatingMode operating_mode = cst::joint)
+                OperatingMode operating_mode = OperatingMode::joint)
             {
                 throw errors::Error("reg_moving_speed_angle not implemented for this protocol");
             }
@@ -69,7 +69,7 @@ namespace dynamixel {
             static inline InstructionPacket<protocols::Protocol1> set_moving_speed_angle(
                 typename protocols::Protocol1::id_t id,
                 double rad_per_s,
-                cst::OperatingMode operating_mode)
+                OperatingMode operating_mode)
             {
                 moving_speed_t speed_ticks = angular_speed_to_ticks(id, rad_per_s,
                     operating_mode);
@@ -80,7 +80,7 @@ namespace dynamixel {
             static inline InstructionPacket<protocols::Protocol1> reg_moving_speed_angle(
                 typename protocols::Protocol1::id_t id,
                 double rad_per_s,
-                cst::OperatingMode operating_mode)
+                OperatingMode operating_mode)
             {
                 moving_speed_t speed_ticks = angular_speed_to_ticks(id, rad_per_s,
                     operating_mode);
@@ -95,13 +95,13 @@ namespace dynamixel {
             static inline moving_speed_t angular_speed_to_ticks(
                 typename protocols::Protocol1::id_t id,
                 double rad_per_s,
-                cst::OperatingMode operating_mode)
+                OperatingMode operating_mode)
             {
                 // convert radians per second to ticks
                 int32_t speed_ticks = round(60 * rad_per_s / (two_pi * ct_t::rpm_per_tick));
 
                 // The actuator is operated as a wheel (continuous rotation)
-                if (operating_mode == cst::wheel) {
+                if (operating_mode == OperatingMode::wheel) {
                     // Check that desired speed is within the actuator's bounds
                     if (!(abs(speed_ticks) >= ct_t::min_goal_speed && abs(speed_ticks) <= ct_t::max_goal_speed)) {
                         double min_goal_speed = -ct_t::max_goal_speed * ct_t::rpm_per_tick * two_pi / 60;
@@ -116,7 +116,7 @@ namespace dynamixel {
                     }
                 }
                 // The actuator is operated as a joint (not continuous rotation)
-                else if (operating_mode == cst::joint) {
+                else if (operating_mode == OperatingMode::joint) {
                     if (!(speed_ticks >= ct_t::min_goal_speed && speed_ticks <= ct_t::max_goal_speed)) {
                         double min_goal_speed = ct_t::min_goal_speed * ct_t::rpm_per_tick * two_pi / 60;
                         double max_goal_speed = ct_t::max_goal_speed * ct_t::rpm_per_tick * two_pi / 60;
@@ -137,7 +137,7 @@ namespace dynamixel {
             static inline InstructionPacket<protocols::Protocol2> set_moving_speed_angle(
                 typename protocols::Protocol2::id_t id,
                 double rad_per_s,
-                cst::OperatingMode operating_mode)
+                OperatingMode operating_mode)
             {
                 moving_speed_t speed_ticks = angular_speed_to_ticks(id, rad_per_s);
 
@@ -147,7 +147,7 @@ namespace dynamixel {
             static inline InstructionPacket<protocols::Protocol2> reg_moving_speed_angle(
                 typename protocols::Protocol2::id_t id,
                 double rad_per_s,
-                cst::OperatingMode operating_mode)
+                OperatingMode operating_mode)
             {
                 moving_speed_t speed_ticks = angular_speed_to_ticks(id, rad_per_s);
 
@@ -175,7 +175,7 @@ namespace dynamixel {
                 return (moving_speed_t)speed_ticks;
             }
         };
-    }
-}
+    } // namespace servos
+} // namespace dynamixel
 
 #endif // DYNAMIXEL_SERVOS_PROTOSPECIFICPACKETS_HPP_

--- a/src/dynamixel/servos/servo.hpp
+++ b/src/dynamixel/servos/servo.hpp
@@ -309,7 +309,7 @@ namespace dynamixel {
 
             typename protocol_t::id_t _id;
         };
-    }
-}
+    } // namespace servos
+} // namespace dynamixel
 
 #endif

--- a/src/dynamixel/servos/servo.hpp
+++ b/src/dynamixel/servos/servo.hpp
@@ -221,22 +221,22 @@ namespace dynamixel {
             // =================================================================
             // Speed-specific
 
-            static inline InstructionPacket<protocol_t> set_moving_speed_angle(typename Servo<Model>::protocol_t::id_t id, double rad_per_s, cst::OperatingMode operating_mode)
+            static inline InstructionPacket<protocol_t> set_moving_speed_angle(typename Servo<Model>::protocol_t::id_t id, double rad_per_s, OperatingMode operating_mode)
             {
                 return ProtocolSpecificPackets<Model, protocol_t>::set_moving_speed_angle(id, rad_per_s, operating_mode);
             }
 
-            static inline InstructionPacket<protocol_t> reg_moving_speed_angle(typename Servo<Model>::protocol_t::id_t id, double rad_per_s, cst::OperatingMode operating_mode)
+            static inline InstructionPacket<protocol_t> reg_moving_speed_angle(typename Servo<Model>::protocol_t::id_t id, double rad_per_s, OperatingMode operating_mode)
             {
                 return ProtocolSpecificPackets<Model, protocol_t>::reg_moving_speed_angle(id, rad_per_s, operating_mode);
             }
 
-            InstructionPacket<protocol_t> set_moving_speed_angle(double rad_per_s, cst::OperatingMode operating_mode = cst::joint) const override
+            InstructionPacket<protocol_t> set_moving_speed_angle(double rad_per_s, OperatingMode operating_mode = OperatingMode::joint) const override
             {
                 return Model::set_moving_speed_angle(this->_id, rad_per_s, operating_mode);
             }
 
-            InstructionPacket<protocol_t> reg_moving_speed_angle(double rad_per_s, cst::OperatingMode operating_mode = cst::joint) const override
+            InstructionPacket<protocol_t> reg_moving_speed_angle(double rad_per_s, OperatingMode operating_mode = OperatingMode::joint) const override
             {
                 return Model::reg_moving_speed_angle(this->_id, rad_per_s, operating_mode);
             }

--- a/src/dynamixel/status_packet.hpp
+++ b/src/dynamixel/status_packet.hpp
@@ -68,6 +68,6 @@ namespace dynamixel {
     {
         return st.print(os);
     }
-}
+} // namespace dynamixel
 
 #endif

--- a/src/dynamixel/status_packet.hpp
+++ b/src/dynamixel/status_packet.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <stdint.h>
 #include <cassert>
+#include <iostream>
 
 #include "./errors/error.hpp"
 

--- a/src/tools/utility.hpp
+++ b/src/tools/utility.hpp
@@ -514,7 +514,7 @@ namespace dynamixel {
             for (auto id : ids) {
                 _serial_interface.send(_servos.at(id)->reg_moving_speed_angle(
                     speed,
-                    wheel_mode ? cst::wheel : cst::joint));
+                    wheel_mode ? OperatingMode::wheel : OperatingMode::joint));
 
                 StatusPacket<Protocol> status;
                 _serial_interface.recv(status);
@@ -546,7 +546,7 @@ namespace dynamixel {
             // "Action" (see bellow) command to enact the change
             for (auto servo : _servos) {
                 _serial_interface.send(servo.second->reg_moving_speed_angle(speed,
-                    wheel_mode ? cst::wheel : cst::joint));
+                    wheel_mode ? OperatingMode::wheel : OperatingMode::joint));
 
                 StatusPacket<Protocol> status;
                 _serial_interface.recv(status);
@@ -586,7 +586,7 @@ namespace dynamixel {
             for (int i = 0; i < ids.size(); i++) {
                 _serial_interface.send(
                     _servos.at(ids[i])->reg_moving_speed_angle(speeds[i],
-                        wheel_mode ? cst::wheel : cst::joint));
+                        wheel_mode ? OperatingMode::wheel : OperatingMode::joint));
 
                 StatusPacket<Protocol> status;
                 _serial_interface.recv(status);


### PR DESCRIPTION
Two changes : comments and operating mode.

I moved from enum to scoped enum, that looks better. It is also easier to use for client code as it makes more sense to use `OperatingMode::wheel` than `cst::wheel`.

Was tested on actuators with protocol 1 and 2