### PR TITLE
Get signed position 

### DIFF
--- a/src/dynamixel/servos/servo.hpp
+++ b/src/dynamixel/servos/servo.hpp
@@ -195,7 +195,7 @@ namespace dynamixel {
             {
                 typename Servo<Model>::ct_t::present_position_t pos;
                 Servo<Model>::protocol_t::unpack_data(st.parameters(), pos);
-                double deg = ((pos - ct_t::min_goal_position) * (ct_t::max_goal_angle_deg - ct_t::min_goal_angle_deg) / (ct_t::max_goal_position - ct_t::min_goal_position)) + ct_t::min_goal_angle_deg;
+                double deg = (((double)pos - ct_t::min_goal_position) * (ct_t::max_goal_angle_deg - ct_t::min_goal_angle_deg) / (ct_t::max_goal_position - ct_t::min_goal_position)) + ct_t::min_goal_angle_deg;
                 double rad = deg / 57.2958;
                 return rad;
             }


### PR DESCRIPTION
Fixes issue #64 
I think this occurs cause of the situation described [here](https://stackoverflow.com/questions/34545445/positive-integers-that-multiply-to-a-negative-value). The right hand side of the equation [here](https://github.com/resibots/libdynamixel/blob/280f3a32812a57b66963dd06af4c25fc1074dd52/src/dynamixel/servos/servo.hpp#L198) perhaps overflows the double value in certain cases